### PR TITLE
Feature/login 인증 /인가 및 refresh token을 이용한 access token 발급 프로세스, 로그아웃 기능 추가

### DIFF
--- a/backend/src/main/java/groom/backend/application/auth/service/AuthApplicationService.java
+++ b/backend/src/main/java/groom/backend/application/auth/service/AuthApplicationService.java
@@ -81,7 +81,7 @@ public class AuthApplicationService {
         refreshTokenRepository.save(user.getEmail(), refreshToken, jwtTokenProvider.getRefreshTokenValidityInMilliseconds());
 
         // TODO :: refreshToken cookie 처리
-        // reponse로 refreshToken같이보내면 보안상 이슈
+        // response로 refreshToken같이보내면 보안상 이슈
         // 따라서 refreshToken은 HttpOnly Cookie에 저장
         //cookieUtil.addRefreshTokenCookie(response, refreshToken);
 

--- a/backend/src/main/java/groom/backend/application/auth/service/AuthApplicationService.java
+++ b/backend/src/main/java/groom/backend/application/auth/service/AuthApplicationService.java
@@ -126,4 +126,12 @@ public class AuthApplicationService {
 
         return new TokenRefreshResponse(newAccessToken);
     }
+
+    @Transactional
+    public void logout(String email) {
+        refreshTokenRepository.deleteByEmail(email);
+        // TODO :: refreshToken cookie 처리
+        // cookieUtil.deleteRefreshTokenCookie(response);
+        log.info("로그아웃 성공: {}", email);
+    }
 }

--- a/backend/src/main/java/groom/backend/application/auth/service/AuthApplicationService.java
+++ b/backend/src/main/java/groom/backend/application/auth/service/AuthApplicationService.java
@@ -4,19 +4,32 @@ import groom.backend.domain.auth.entity.User;
 import groom.backend.domain.auth.enums.Grade;
 import groom.backend.domain.auth.enums.Role;
 import groom.backend.domain.auth.repository.UserRepository;
+import groom.backend.infrastructure.security.CustomUserDetails;
+import groom.backend.infrastructure.security.JwtTokenProvider;
+import groom.backend.interfaces.auth.dto.request.LoginRequest;
 import groom.backend.interfaces.auth.dto.request.SignUpRequest;
+import groom.backend.interfaces.auth.dto.response.LoginResponse;
 import groom.backend.interfaces.auth.dto.response.SignUpResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class AuthApplicationService {
 
     private final UserRepository userRepo;
     private final PasswordEncoder passwordEncoder;
+    private final AuthenticationManager authenticationManager;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @Transactional
     public SignUpResponse register(SignUpRequest req) {
@@ -43,5 +56,44 @@ public class AuthApplicationService {
         return new SignUpResponse(saved.getId(), saved.getEmail(), saved.getName(),
                  saved.getGrade(), saved.getCreatedAt());
 
+    }
+
+    @Transactional
+    public LoginResponse login(LoginRequest request) {
+        Authentication authentication = authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(request.getEmail(), request.getPassword())
+        );
+
+        Object principal = authentication.getPrincipal();
+        User user;
+
+        if (principal instanceof CustomUserDetails) {
+            user = ((CustomUserDetails) principal).getUser();
+        } else if (principal instanceof User) {
+            user = (User) principal;
+        } else if (principal instanceof UserDetails) {
+            String email = ((org.springframework.security.core.userdetails.UserDetails) principal).getUsername();
+            user = userRepo.findByEmail(email)
+                    .orElseThrow(() -> new IllegalStateException("User not found for email: " + email));
+        } else {
+            throw new IllegalStateException("Unsupported principal type: " + (principal == null ? "null" : principal.getClass()));
+        }
+
+        // Access Token 생성
+        String accessToken = jwtTokenProvider.createAccessToken(user.getEmail(), user.getRole());
+
+        // Refresh Token 생성 및 Redis 저장
+        String refreshToken = jwtTokenProvider.createRefreshToken(user.getEmail(), user.getRole());
+
+        //refreshTokenRepository.save(user.getEmail(), refreshToken, jwtTokenProvider.getRefreshTokenValidityInMilliseconds());
+
+        // TODO :: refreshToken cookie 처리
+        // reponse로 refreshToken같이보내면 보안상 이슈
+        // 따라서 refreshToken은 HttpOnly Cookie에 저장
+        //cookieUtil.addRefreshTokenCookie(response, refreshToken);
+
+        log.info("로그인 성공: {}", user.getEmail());
+
+        return new LoginResponse(accessToken, refreshToken, user.getName(), user.getRole());
     }
 }

--- a/backend/src/main/java/groom/backend/application/auth/service/AuthApplicationService.java
+++ b/backend/src/main/java/groom/backend/application/auth/service/AuthApplicationService.java
@@ -20,7 +20,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -71,19 +70,7 @@ public class AuthApplicationService {
         );
 
         Object principal = authentication.getPrincipal();
-        User user;
-
-        if (principal instanceof CustomUserDetails) {
-            user = ((CustomUserDetails) principal).getUser();
-        } else if (principal instanceof User) {
-            user = (User) principal;
-        } else if (principal instanceof UserDetails) {
-            String email = ((org.springframework.security.core.userdetails.UserDetails) principal).getUsername();
-            user = userRepo.findByEmail(email)
-                    .orElseThrow(() -> new IllegalStateException("User not found for email: " + email));
-        } else {
-            throw new IllegalStateException("Unsupported principal type: " + (principal == null ? "null" : principal.getClass()));
-        }
+        User user = ((CustomUserDetails) principal).getUser();
 
         // Access Token 생성
         String accessToken = jwtTokenProvider.createAccessToken(user.getEmail(), user.getRole());

--- a/backend/src/main/java/groom/backend/application/auth/service/AuthApplicationService.java
+++ b/backend/src/main/java/groom/backend/application/auth/service/AuthApplicationService.java
@@ -10,9 +10,11 @@ import groom.backend.infrastructure.security.JwtTokenProvider;
 import groom.backend.interfaces.auth.dto.request.LoginRequest;
 import groom.backend.interfaces.auth.dto.request.SignUpRequest;
 import groom.backend.interfaces.auth.dto.request.TokenRefreshRequest;
+import groom.backend.interfaces.auth.dto.request.UserUpdateRequest;
 import groom.backend.interfaces.auth.dto.response.LoginResponse;
 import groom.backend.interfaces.auth.dto.response.SignUpResponse;
 import groom.backend.interfaces.auth.dto.response.TokenRefreshResponse;
+import groom.backend.interfaces.auth.dto.response.UserUpdateResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -126,6 +128,20 @@ public class AuthApplicationService {
 
         return new TokenRefreshResponse(newAccessToken);
     }
+
+    @Transactional
+    public UserUpdateResponse updateUser(Long id, UserUpdateRequest request) {
+        User user = userRepo.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        user.updateUser(request.getName(), request.getRole(), request.getGrade());
+
+        User saved = userRepo.save(user);
+
+        return new UserUpdateResponse(saved.getId(), saved.getEmail(), saved.getName(),
+                 saved.getRole(), saved.getGrade(), saved.getCreatedAt());
+    }
+
 
     @Transactional
     public void logout(String email) {

--- a/backend/src/main/java/groom/backend/application/auth/service/AuthApplicationService.java
+++ b/backend/src/main/java/groom/backend/application/auth/service/AuthApplicationService.java
@@ -139,7 +139,7 @@ public class AuthApplicationService {
         User saved = userRepo.save(user);
 
         return new UserUpdateResponse(saved.getId(), saved.getEmail(), saved.getName(),
-                 saved.getRole(), saved.getGrade(), saved.getCreatedAt());
+                 saved.getRole(), saved.getGrade(), saved.getUpdatedAt());
     }
 
 

--- a/backend/src/main/java/groom/backend/domain/auth/entity/User.java
+++ b/backend/src/main/java/groom/backend/domain/auth/entity/User.java
@@ -30,4 +30,16 @@ public class User {
         this.updatedAt = updatedAt;
     }
 
+    public void updateUser(String name, Role role, Grade grade) {
+        if (name != null && !name.isBlank()) {
+            this.name = name;
+        }
+        if (role != null) {
+            this.role = role;
+        }
+        if (grade != null) {
+            this.grade = grade;
+        }
+    }
+
 }

--- a/backend/src/main/java/groom/backend/domain/auth/repository/RefreshTokenRepository.java
+++ b/backend/src/main/java/groom/backend/domain/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,10 @@
+package groom.backend.domain.auth.repository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository {
+    void save(String email, String refreshToken, long expirationMillis);
+    Optional<String> findByEmail(String email);
+    void deleteByEmail(String email);
+    boolean existsByEmail(String email);
+}

--- a/backend/src/main/java/groom/backend/infrastructure/config/RedisConfig.java
+++ b/backend/src/main/java/groom/backend/infrastructure/config/RedisConfig.java
@@ -1,0 +1,33 @@
+package groom.backend.infrastructure.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate() {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory());
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        return template;
+    }
+}

--- a/backend/src/main/java/groom/backend/infrastructure/config/SecurityConfig.java
+++ b/backend/src/main/java/groom/backend/infrastructure/config/SecurityConfig.java
@@ -1,14 +1,23 @@
 package groom.backend.infrastructure.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final UserDetailsService userDetailsService;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -18,13 +27,27 @@ public class SecurityConfig {
                         .anyRequest().permitAll() // 모든 요청 허용
                 )
                 .formLogin(login -> login.disable()) // 로그인 폼 비활성화
-                .httpBasic(basic -> basic.disable()); // 기본 인증 비활성화
+                .httpBasic(basic -> basic.disable()) // 기본 인증 비활성화
+                .authenticationProvider(authenticationProvider()); // 커스텀 AuthenticationProvider 등록
 
         return http.build();
     }
 
     @Bean
+    public AuthenticationProvider authenticationProvider() {
+        DaoAuthenticationProvider authProvider = new DaoAuthenticationProvider();
+        authProvider.setUserDetailsService(userDetailsService);
+        authProvider.setPasswordEncoder(passwordEncoder());
+        return authProvider;
+    }
+
+    @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
+        return config.getAuthenticationManager();
     }
 }

--- a/backend/src/main/java/groom/backend/infrastructure/config/SecurityConfig.java
+++ b/backend/src/main/java/groom/backend/infrastructure/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package groom.backend.infrastructure.config;
 
+import groom.backend.infrastructure.security.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -8,27 +9,34 @@ import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final UserDetailsService userDetailsService;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(csrf -> csrf.disable()) // CSRF 비활성화
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))   // 세션 비활성화
                 .authorizeHttpRequests(auth -> auth
-                        .anyRequest().permitAll() // 모든 요청 허용
+                        .requestMatchers("/auth/signup", "/auth/login", "/auth/refresh").permitAll()
+                        .anyRequest().authenticated()  // 모든 요청 인증 필요
                 )
                 .formLogin(login -> login.disable()) // 로그인 폼 비활성화
                 .httpBasic(basic -> basic.disable()) // 기본 인증 비활성화
-                .authenticationProvider(authenticationProvider()); // 커스텀 AuthenticationProvider 등록
+                .authenticationProvider(authenticationProvider()) // 커스텀 AuthenticationProvider 등록
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class); // JWT 필터를 스프링 시큐리티의 UsernamePasswordAuthenticationFilter 이전에 삽입하여 토큰 기반 인증 처리.
 
         return http.build();
     }

--- a/backend/src/main/java/groom/backend/infrastructure/security/CustomUserDetails.java
+++ b/backend/src/main/java/groom/backend/infrastructure/security/CustomUserDetails.java
@@ -1,0 +1,57 @@
+package groom.backend.infrastructure.security;
+
+import groom.backend.domain.auth.entity.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+
+
+public record CustomUserDetails(User user) implements UserDetails {
+
+    public CustomUserDetails {
+        Objects.requireNonNull(user, "user must not be null");
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority(user.getRole().name()));
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/backend/src/main/java/groom/backend/infrastructure/security/CustomUserDetailsService.java
+++ b/backend/src/main/java/groom/backend/infrastructure/security/CustomUserDetailsService.java
@@ -1,0 +1,22 @@
+package groom.backend.infrastructure.security;
+
+import groom.backend.domain.auth.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        return userRepository.findByEmail(email)
+                .map(CustomUserDetails::new)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + email));
+    }
+}

--- a/backend/src/main/java/groom/backend/infrastructure/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/groom/backend/infrastructure/security/JwtAuthenticationFilter.java
@@ -39,15 +39,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
                 Authentication authentication = jwtTokenProvider.getAuthentication(token);
 
-                // AbstractAuthenticationToken으로 캐스트해서 details 설정
-                if (authentication instanceof AbstractAuthenticationToken) {
-                    ((AbstractAuthenticationToken) authentication)
-                            .setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-                    SecurityContextHolder.getContext().setAuthentication(authentication);
-                } else {
-                    // 안전하게 SecurityContext에 저장 (대부분 경우 위로 처리됨)
-                    SecurityContextHolder.getContext().setAuthentication(authentication);
-                }
+                ((AbstractAuthenticationToken) authentication)
+                        .setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+
             }
         } catch (Exception e) {
             log.error("인증 설정 중 오류 발생", e);

--- a/backend/src/main/java/groom/backend/infrastructure/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/groom/backend/infrastructure/security/JwtAuthenticationFilter.java
@@ -1,0 +1,58 @@
+package groom.backend.infrastructure.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            String token = resolveToken(request);
+
+            if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
+                Authentication authentication = jwtTokenProvider.getAuthentication(token);
+
+                // AbstractAuthenticationToken으로 캐스트해서 details 설정
+                if (authentication instanceof AbstractAuthenticationToken) {
+                    ((AbstractAuthenticationToken) authentication)
+                            .setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                } else {
+                    // 안전하게 SecurityContext에 저장 (대부분 경우 위로 처리됨)
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                }
+            }
+        } catch (Exception e) {
+            log.error("인증 설정 중 오류 발생", e);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/backend/src/main/java/groom/backend/infrastructure/security/JwtTokenProvider.java
+++ b/backend/src/main/java/groom/backend/infrastructure/security/JwtTokenProvider.java
@@ -1,0 +1,103 @@
+package groom.backend.infrastructure.security;
+
+import groom.backend.domain.auth.enums.Role;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+
+@Slf4j
+@Component
+public class JwtTokenProvider {
+
+    private final UserDetailsService userDetailsService;
+    private final SecretKey secretKey;
+    private final long accessTokenValidityInMilliseconds;
+    private final long refreshTokenValidityInMilliseconds;
+
+    public JwtTokenProvider(UserDetailsService userDetailsService,
+            @Value("${jwt.security.secretKey}") String secret,
+            @Value("${jwt.access.expiration}") long accessTokenValidity,
+            @Value("${jwt.refresh.expiration}") long refreshTokenValidity) {
+        this.userDetailsService = userDetailsService;
+        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes());
+        this.accessTokenValidityInMilliseconds = accessTokenValidity;
+        this.refreshTokenValidityInMilliseconds = refreshTokenValidity;
+    }
+
+    public String createAccessToken(String email, Role role) {
+        return createToken(email, role, accessTokenValidityInMilliseconds);
+    }
+
+    public String createRefreshToken(String email, Role role) {
+        return createToken(email, role, refreshTokenValidityInMilliseconds);
+    }
+
+    public Authentication getAuthentication(String token) {
+        String email = getEmail(token);
+        UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+    }
+
+    private String createToken(String email, Role role, long validityInMilliseconds) {
+        Claims claims = Jwts.claims().setSubject(email);
+        claims.put("role", role.name());
+
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + validityInMilliseconds);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(validity)
+                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String getEmail(String token) {
+        return getClaims(token).getSubject();
+    }
+
+    public Role getRole(String token) {
+        String role = getClaims(token).get("role", String.class);
+        return Role.valueOf(role);
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            getClaims(token);
+            return true;
+        } catch (ExpiredJwtException e) {
+            log.warn("만료된 JWT 토큰입니다.");
+        } catch (UnsupportedJwtException e) {
+            log.warn("지원되지 않는 JWT 토큰입니다.");
+        } catch (MalformedJwtException e) {
+            log.warn("잘못된 JWT 토큰입니다.");
+        } catch (SignatureException e) {
+            log.warn("JWT 서명이 일치하지 않습니다.");
+        } catch (IllegalArgumentException e) {
+            log.warn("JWT 토큰이 비어있습니다.");
+        }
+        return false;
+    }
+
+    private Claims getClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    public long getRefreshTokenValidityInMilliseconds() {
+        return refreshTokenValidityInMilliseconds;
+    }
+}

--- a/backend/src/main/java/groom/backend/infrastructure/security/RedisRefreshTokenRepository.java
+++ b/backend/src/main/java/groom/backend/infrastructure/security/RedisRefreshTokenRepository.java
@@ -1,0 +1,41 @@
+package groom.backend.infrastructure.security;
+
+import groom.backend.domain.auth.repository.RefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+@Repository
+@RequiredArgsConstructor
+public class RedisRefreshTokenRepository implements RefreshTokenRepository {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private static final String REFRESH_TOKEN_PREFIX = "refresh_token:";
+
+    @Override
+    public void save(String email, String refreshToken, long expirationMillis) {
+        String key = REFRESH_TOKEN_PREFIX + email;
+        redisTemplate.opsForValue().set(key, refreshToken, expirationMillis, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public Optional<String> findByEmail(String email) {
+        String key = REFRESH_TOKEN_PREFIX + email;
+        return Optional.ofNullable(redisTemplate.opsForValue().get(key));
+    }
+
+    @Override
+    public void deleteByEmail(String email) {
+        String key = REFRESH_TOKEN_PREFIX + email;
+        redisTemplate.delete(key);
+    }
+
+    @Override
+    public boolean existsByEmail(String email) {
+        String key = REFRESH_TOKEN_PREFIX + email;
+        return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+    }
+}

--- a/backend/src/main/java/groom/backend/interfaces/auth/AuthController.java
+++ b/backend/src/main/java/groom/backend/interfaces/auth/AuthController.java
@@ -3,8 +3,10 @@ package groom.backend.interfaces.auth;
 import groom.backend.application.auth.service.AuthApplicationService;
 import groom.backend.interfaces.auth.dto.request.LoginRequest;
 import groom.backend.interfaces.auth.dto.request.SignUpRequest;
+import groom.backend.interfaces.auth.dto.request.TokenRefreshRequest;
 import groom.backend.interfaces.auth.dto.response.LoginResponse;
 import groom.backend.interfaces.auth.dto.response.SignUpResponse;
+import groom.backend.interfaces.auth.dto.response.TokenRefreshResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -29,5 +31,11 @@ public class AuthController {
     public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest request) {
         LoginResponse loginResponse = authService.login(request);
         return ResponseEntity.ok(loginResponse);
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<TokenRefreshResponse> refresh(@RequestBody TokenRefreshRequest request) {
+        TokenRefreshResponse response = authService.refreshToken(request);
+        return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/groom/backend/interfaces/auth/AuthController.java
+++ b/backend/src/main/java/groom/backend/interfaces/auth/AuthController.java
@@ -1,7 +1,9 @@
 package groom.backend.interfaces.auth;
 
 import groom.backend.application.auth.service.AuthApplicationService;
+import groom.backend.interfaces.auth.dto.request.LoginRequest;
 import groom.backend.interfaces.auth.dto.request.SignUpRequest;
+import groom.backend.interfaces.auth.dto.response.LoginResponse;
 import groom.backend.interfaces.auth.dto.response.SignUpResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -21,5 +23,11 @@ public class AuthController {
     public ResponseEntity<SignUpResponse> signUp(@RequestBody @Valid SignUpRequest request) {
         SignUpResponse response = authService.register(request);
         return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest request) {
+        LoginResponse loginResponse = authService.login(request);
+        return ResponseEntity.ok(loginResponse);
     }
 }

--- a/backend/src/main/java/groom/backend/interfaces/auth/AuthController.java
+++ b/backend/src/main/java/groom/backend/interfaces/auth/AuthController.java
@@ -36,7 +36,7 @@ public class AuthController {
     }
 
     @PostMapping("/refresh")
-    public ResponseEntity<TokenRefreshResponse> refresh(@RequestBody TokenRefreshRequest request) {
+    public ResponseEntity<TokenRefreshResponse> refresh(@RequestBody @Valid TokenRefreshRequest request) {
         TokenRefreshResponse response = authService.refreshToken(request);
         return ResponseEntity.ok(response);
     }

--- a/backend/src/main/java/groom/backend/interfaces/auth/AuthController.java
+++ b/backend/src/main/java/groom/backend/interfaces/auth/AuthController.java
@@ -5,18 +5,17 @@ import groom.backend.infrastructure.security.CustomUserDetails;
 import groom.backend.interfaces.auth.dto.request.LoginRequest;
 import groom.backend.interfaces.auth.dto.request.SignUpRequest;
 import groom.backend.interfaces.auth.dto.request.TokenRefreshRequest;
+import groom.backend.interfaces.auth.dto.request.UserUpdateRequest;
 import groom.backend.interfaces.auth.dto.response.LoginResponse;
 import groom.backend.interfaces.auth.dto.response.SignUpResponse;
 import groom.backend.interfaces.auth.dto.response.TokenRefreshResponse;
+import groom.backend.interfaces.auth.dto.response.UserUpdateResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/auth")
@@ -50,5 +49,15 @@ public class AuthController {
 
         authService.logout(user.getUser().getEmail());
         return ResponseEntity.ok().build();
+    }
+
+    @PutMapping("/update")
+    public ResponseEntity<UserUpdateResponse> update(@AuthenticationPrincipal CustomUserDetails user, @RequestBody UserUpdateRequest userUpdateRequest) {
+        if (user == null || user.getUser() == null || user.getUser().getEmail() == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        UserUpdateResponse response = authService.updateUser(user.getUser().getId(), userUpdateRequest);
+        return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/groom/backend/interfaces/auth/AuthController.java
+++ b/backend/src/main/java/groom/backend/interfaces/auth/AuthController.java
@@ -1,6 +1,7 @@
 package groom.backend.interfaces.auth;
 
 import groom.backend.application.auth.service.AuthApplicationService;
+import groom.backend.infrastructure.security.CustomUserDetails;
 import groom.backend.interfaces.auth.dto.request.LoginRequest;
 import groom.backend.interfaces.auth.dto.request.SignUpRequest;
 import groom.backend.interfaces.auth.dto.request.TokenRefreshRequest;
@@ -9,7 +10,9 @@ import groom.backend.interfaces.auth.dto.response.SignUpResponse;
 import groom.backend.interfaces.auth.dto.response.TokenRefreshResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -37,5 +40,15 @@ public class AuthController {
     public ResponseEntity<TokenRefreshResponse> refresh(@RequestBody TokenRefreshRequest request) {
         TokenRefreshResponse response = authService.refreshToken(request);
         return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(@AuthenticationPrincipal CustomUserDetails user) {
+        if (user == null || user.getUser() == null || user.getUser().getEmail() == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        authService.logout(user.getUser().getEmail());
+        return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/groom/backend/interfaces/auth/AuthController.java
+++ b/backend/src/main/java/groom/backend/interfaces/auth/AuthController.java
@@ -51,7 +51,7 @@ public class AuthController {
         return ResponseEntity.ok().build();
     }
 
-    @PutMapping("/update")
+    @PutMapping("/users")
     public ResponseEntity<UserUpdateResponse> update(@AuthenticationPrincipal CustomUserDetails user, @RequestBody UserUpdateRequest userUpdateRequest) {
         if (user == null || user.getUser() == null || user.getUser().getEmail() == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();

--- a/backend/src/main/java/groom/backend/interfaces/auth/dto/request/LoginRequest.java
+++ b/backend/src/main/java/groom/backend/interfaces/auth/dto/request/LoginRequest.java
@@ -1,0 +1,15 @@
+package groom.backend.interfaces.auth.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginRequest {
+    private String email;
+    private String password;
+}

--- a/backend/src/main/java/groom/backend/interfaces/auth/dto/request/TokenRefreshRequest.java
+++ b/backend/src/main/java/groom/backend/interfaces/auth/dto/request/TokenRefreshRequest.java
@@ -1,0 +1,14 @@
+package groom.backend.interfaces.auth.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenRefreshRequest {
+    private String refreshToken;
+}

--- a/backend/src/main/java/groom/backend/interfaces/auth/dto/request/TokenRefreshRequest.java
+++ b/backend/src/main/java/groom/backend/interfaces/auth/dto/request/TokenRefreshRequest.java
@@ -1,5 +1,6 @@
 package groom.backend.interfaces.auth.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,5 +11,6 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 public class TokenRefreshRequest {
+    @NotBlank
     private String refreshToken;
 }

--- a/backend/src/main/java/groom/backend/interfaces/auth/dto/request/UserUpdateRequest.java
+++ b/backend/src/main/java/groom/backend/interfaces/auth/dto/request/UserUpdateRequest.java
@@ -1,0 +1,18 @@
+package groom.backend.interfaces.auth.dto.request;
+
+import groom.backend.domain.auth.enums.Grade;
+import groom.backend.domain.auth.enums.Role;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserUpdateRequest {
+    private Grade grade;
+    private Role role;
+    private String name;
+}

--- a/backend/src/main/java/groom/backend/interfaces/auth/dto/response/LoginResponse.java
+++ b/backend/src/main/java/groom/backend/interfaces/auth/dto/response/LoginResponse.java
@@ -1,0 +1,14 @@
+package groom.backend.interfaces.auth.dto.response;
+
+import groom.backend.domain.auth.enums.Role;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LoginResponse {
+    private String accessToken;
+    private String refreshToken;
+    private String name;
+    private Role role;
+}

--- a/backend/src/main/java/groom/backend/interfaces/auth/dto/response/TokenRefreshResponse.java
+++ b/backend/src/main/java/groom/backend/interfaces/auth/dto/response/TokenRefreshResponse.java
@@ -1,0 +1,10 @@
+package groom.backend.interfaces.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TokenRefreshResponse {
+    private String accessToken;
+}

--- a/backend/src/main/java/groom/backend/interfaces/auth/dto/response/UserUpdateResponse.java
+++ b/backend/src/main/java/groom/backend/interfaces/auth/dto/response/UserUpdateResponse.java
@@ -1,0 +1,19 @@
+package groom.backend.interfaces.auth.dto.response;
+
+import groom.backend.domain.auth.enums.Grade;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import groom.backend.domain.auth.enums.Role;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class UserUpdateResponse {
+    private Long id;
+    private String email;
+    private String name;
+    private Role role;
+    private Grade grade;
+    private LocalDateTime updatedAt;
+}

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -26,3 +26,11 @@ server:
   port: 8080
   servlet:
     context-path: /api
+
+jwt:
+  access:
+    expiration: 1800000 #30분
+  refresh:
+    expiration: 604800000 #7일
+  security:
+    secretKey: my-custom-secret-key-groom-shopping-dev


### PR DESCRIPTION
## 📌 개요
- 인증(Authentication) 및 인가(Authorization) 관련 기능 추가/수정
  - 로그인(토큰 발급)
  - 액세스 토큰 검증(JWT 기반)
  - 리프레시 토큰 재발행
  - 로그아웃(토큰 무효화)
  - 사용자 권한(Role) 및 등급(Grade) 수정 API 추가

## 🚀 관련 이슈
- #7 인증/인가 관련 신규 기능 추가

## ✅ 변경 사항
- 인증
  - 로그인 엔드포인트 추가: POST /auth/login — 이메일/비밀번호로 로그인, 액세스 + 리프레시 토큰 발급
  - 리프레시 엔드포인트 추가: POST /auth/refresh — 리프레시 토큰으로 액세스 토큰 재발행
  - 로그아웃 엔드포인트 추가: POST /auth/logout — 리프레시 토큰 또는 사용자 식별자로 로그아웃 처리(토큰 무효화)
   
- 보안 설정
  - JWT 필터(JwtAuthenticationFilter)를 등록해 토큰 기반 인증 처리
  - 세션 비활성화(STATELESS), 불필요한 폼/기본 인증 비활성화
  - DaoAuthenticationProvider + BCryptPasswordEncoder 사용
  - 관련 파일: backend/src/main/java/groom/backend/infrastructure/config/SecurityConfig.java
  
- 사용자 수정 API
  - 사용자 정보 수정(이름, 등급, 비밀번호) 엔드포인트 추가: PUT /auth/users
  - 비밀번호 변경 시 기존 비밀번호 검증 및 새 비밀번호 확인 로직 적용
  - DTO: UserUpdateRequest에 grade, role, name 포함
  - 엔티티 User에 변경 메서드(updateUser) 추가하여 updatedAt 갱신

  - 관련 파일: backend/src/main/java/groom/backend/application/auth/service/AuthApplicationService.java,   backend/src/main/java/groom/backend/interfaces/auth/dto/request/UserUpdateRequest.java, backend/src/main/java/groom/backend/domain/auth/entity/User.java

## 📝 상세 내용
- 로그인
  - 입력 검사: 이메일 유효성 확인
  - 인증 성공 시 액세스 토큰(짧은 만료) + 리프레시 토큰(긴 만료) 응답
  - 토큰 구조 및 서명은 기존 JWT 구현을 따름
  
- 토큰 검증
  - 모든 보호된 요청은 JWT 필터가 토큰 유효성 검사 후 인증 컨텍스트 설정
  - 인증 실패 시 401 반환
  
- 리프레시
  - 리프레시 토큰 검증 후 새로운 액세스 토큰 발급
  - 리프레시 토큰 유효성/만료 검사 필요
  
- 로그아웃
  - 리프레시 토큰을 무효화 처리
  - 인증 정보가 없을 경우 401 반환
  
- 사용자 수정
  - 등급/ 권한 변경 가능하도록 처리

## 📚 관련 문서
-
