### PR TITLE
fix : 회원가입 시 등급, 권한 설정 가능하도록 변경

### DIFF
--- a/backend/src/main/java/groom/backend/application/auth/service/AuthApplicationService.java
+++ b/backend/src/main/java/groom/backend/application/auth/service/AuthApplicationService.java
@@ -1,8 +1,6 @@
 package groom.backend.application.auth.service;
 
 import groom.backend.domain.auth.entity.User;
-import groom.backend.domain.auth.enums.Grade;
-import groom.backend.domain.auth.enums.Role;
 import groom.backend.domain.auth.repository.RefreshTokenRepository;
 import groom.backend.domain.auth.repository.UserRepository;
 import groom.backend.infrastructure.security.CustomUserDetails;
@@ -37,8 +35,8 @@ public class AuthApplicationService {
     private final RefreshTokenRepository refreshTokenRepository;
 
     @Transactional
-    public SignUpResponse register(SignUpRequest req) {
-        String email = req.getEmail().toLowerCase().trim();
+    public SignUpResponse register(SignUpRequest request) {
+        String email = request.getEmail().toLowerCase().trim();
 
         if (userRepo.existsByEmail(email)) {
             throw new IllegalArgumentException("Email already registered");
@@ -48,10 +46,10 @@ public class AuthApplicationService {
         User user = new User(
                 null,
                 email,
-                passwordEncoder.encode(req.getPassword()),
-                req.getName(),
-                Role.ROLE_USER,
-                Grade.BRONZE,
+                passwordEncoder.encode(request.getPassword()),
+                request.getName(),
+                request.getRole(),
+                request.getGrade(),
                 null,
                 null
         );
@@ -59,7 +57,7 @@ public class AuthApplicationService {
         User saved = userRepo.save(user);
 
         return new SignUpResponse(saved.getId(), saved.getEmail(), saved.getName(),
-                 saved.getGrade(), saved.getCreatedAt());
+                 saved.getRole(), saved.getGrade(), saved.getCreatedAt());
 
     }
 

--- a/backend/src/main/java/groom/backend/application/auth/service/AuthApplicationService.java
+++ b/backend/src/main/java/groom/backend/application/auth/service/AuthApplicationService.java
@@ -43,6 +43,7 @@ public class AuthApplicationService {
         }
 
         // TODO 객체 생성 팩토리 메서드로 변경 고려
+        // TODO : 개발 편의를 위해 ROLE, GRADE 요청대로 적용 (추후 삭제 예정)
         User user = new User(
                 null,
                 email,

--- a/backend/src/main/java/groom/backend/interfaces/auth/dto/request/SignUpRequest.java
+++ b/backend/src/main/java/groom/backend/interfaces/auth/dto/request/SignUpRequest.java
@@ -18,6 +18,8 @@ public class SignUpRequest {
     private String password;
     @NotBlank
     private String name;
+
+    // TODO : 개발 편의를 위해 임시 추가 (추후 삭제 예정)
     private Role role = Role.ROLE_USER;
     private Grade grade  = Grade.BRONZE;
 

--- a/backend/src/main/java/groom/backend/interfaces/auth/dto/request/SignUpRequest.java
+++ b/backend/src/main/java/groom/backend/interfaces/auth/dto/request/SignUpRequest.java
@@ -2,10 +2,9 @@ package groom.backend.interfaces.auth.dto.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import groom.backend.domain.auth.enums.Grade;
+import groom.backend.domain.auth.enums.Role;
+import lombok.*;
 
 @Getter
 @Setter
@@ -19,4 +18,7 @@ public class SignUpRequest {
     private String password;
     @NotBlank
     private String name;
+    private Role role = Role.ROLE_USER;
+    private Grade grade  = Grade.BRONZE;
+
 }

--- a/backend/src/main/java/groom/backend/interfaces/auth/dto/response/SignUpResponse.java
+++ b/backend/src/main/java/groom/backend/interfaces/auth/dto/response/SignUpResponse.java
@@ -1,6 +1,7 @@
 package groom.backend.interfaces.auth.dto.response;
 
 import groom.backend.domain.auth.enums.Grade;
+import groom.backend.domain.auth.enums.Role;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -12,6 +13,7 @@ public class SignUpResponse {
     private Long id;
     private String email;
     private String name;
+    private Role role;
     private Grade grade;
     private LocalDateTime createdAt;
 }


### PR DESCRIPTION
개발 편의를 위하여 회원가입 시 등급, 권한 설정 가능하도록 변경

## 📌 개요
- 계정을 만들 때 권한, 등급 설정을 해서 개발 편의성을 높이고 싶음

## 🚀 관련 이슈
-closes #13 

## ✅ 변경 사항
사용자의 권한과 등급을 설정가능, 기본 값은 BRONZE, ROLE_USER

## 📝 상세 내용
- endPoint : POST  /auth/signup 
- body :  {
    "email" : "amdin@bronze.com",
    "password" : "1234",
    "name" : "이준원",
    "role" : "ROLE_ADMIN",
    "grade" : "BRONZE"
}

허용 값:
rold -  ROLE_USER, ROLE_ADMIN
grade - BRONZE, SILVER, GOLD, PLATINUM, VIP


## 📚 관련 문서
-
