### PR TITLE
Feature/global exception handler 전역 예외 처리 구현

### DIFF
--- a/backend/src/main/java/groom/backend/common/exception/BusinessException.java
+++ b/backend/src/main/java/groom/backend/common/exception/BusinessException.java
@@ -1,0 +1,34 @@
+package groom.backend.common.exception;
+
+import lombok.Getter;
+
+/**
+ * 비즈니스 로직 예외의 기본 클래스.
+ *
+ * - RuntimeException을 상속하여 트랜잭션 롤백이 자동 적용됨.
+ * - 도메인 규칙 위반, 비즈니스 검증 실패 등의 경우에 사용.
+ * - ErrorCode를 포함하여 일관된 에러 응답을 생성할 수 있음.
+ */
+@Getter
+public class BusinessException extends RuntimeException {
+
+  // 에러 코드 (HTTP 상태 및 기본 메시지 포함)
+  private final ErrorCode errorCode;
+
+  /**
+   * 기본 메시지를 사용하는 생성자
+   */
+  public BusinessException(ErrorCode errorCode) {
+    super(errorCode.getMessage());
+    this.errorCode = errorCode;
+  }
+
+  /**
+   * 세부 메시지를 지정하는 생성자
+   * 기본 제공 메시지보다 상세한 상황 제공을 위해 사용
+   */
+  public BusinessException(ErrorCode errorCode, String detailMessage) {
+    super(detailMessage);
+    this.errorCode = errorCode;
+  }
+}

--- a/backend/src/main/java/groom/backend/common/exception/ErrorCode.java
+++ b/backend/src/main/java/groom/backend/common/exception/ErrorCode.java
@@ -1,0 +1,32 @@
+package groom.backend.common.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 전역적으로 사용되는 에러 코드 정의 Enum.
+ * 각 에러는 HTTP 상태 코드(HttpStatus)와 사용자 메시지를 함께 가짐.
+ *
+ * Controller → Service → Repository 계층에서 발생한 예외를
+ * 표준화된 형태로 응답하기 위해 사용됨.
+ */
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+  // ==================== 공통 에러 코드 ====================
+  INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+  UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
+  FORBIDDEN(HttpStatus.FORBIDDEN, "권한이 없습니다."),
+  NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다."),
+  CONFLICT(HttpStatus.CONFLICT, "이미 존재하는 리소스입니다."),
+  SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.");
+
+  // HTTP 상태 코드
+  private final HttpStatus status;
+
+  // 클라이언트에게 반환될 메시지
+  private final String message;
+}
+

--- a/backend/src/main/java/groom/backend/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/groom/backend/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,59 @@
+package groom.backend.common.exception;
+
+import groom.backend.common.exception.dto.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * 전역 예외 처리 클래스.
+ *
+ * - @RestControllerAdvice: 모든 Controller에서 발생한 예외를 감지하여 처리함.
+ * - 예외 유형별로 다른 ErrorResponse를 생성하여 일관된 형식으로 응답.
+ */
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+  /**
+   * 비즈니스 로직 예외 처리
+   * ex) 쿠폰이 존재하지 않음, 중복 발급 등
+   */
+  @ExceptionHandler(BusinessException.class)
+  public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+    ErrorCode errorCode = e.getErrorCode();
+    log.warn("[BusinessException] {} - {}", errorCode.name(), e.getMessage());
+    return ResponseEntity.status(errorCode.getStatus())
+            .body(ErrorResponse.from(errorCode, e.getMessage()));
+  }
+
+
+  /**
+   * DTO 유효성 검증 실패
+   * ex) @Valid, @NotNull 등을 위반한 경우
+   */
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException e) {
+    String detail = e.getBindingResult().getFieldErrors().stream()
+            .map(err -> err.getField() + ": " + err.getDefaultMessage())
+            .findFirst()
+            .orElse("잘못된 입력값입니다.");
+    log.warn("[ValidationException] {}", detail);
+    return ResponseEntity.badRequest()
+            .body(ErrorResponse.of(HttpStatus.BAD_REQUEST.value(), "INVALID_PARAMETER", detail));
+  }
+
+  /**
+   * 그 외 예상치 못한 모든 예외 처리 (서버 내부 오류)
+   */
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<ErrorResponse> handleException(Exception e) {
+    log.error("[UnhandledException]", e);
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(ErrorResponse.from(ErrorCode.SERVER_ERROR));
+  }
+}
+

--- a/backend/src/main/java/groom/backend/common/exception/dto/ErrorResponse.java
+++ b/backend/src/main/java/groom/backend/common/exception/dto/ErrorResponse.java
@@ -1,0 +1,51 @@
+package groom.backend.common.exception.dto;
+
+import groom.backend.common.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 예외 발생 시 클라이언트에게 반환되는 표준 JSON 응답 DTO.
+ *
+ * 예시:
+ * {
+ *   "status": 404,
+ *   "code": "NOT_FOUND",
+ *   "message": "요청한 리소스를 찾을 수 없습니다."
+ * }
+ */
+@Getter
+@AllArgsConstructor(staticName = "of")
+public class ErrorResponse {
+
+  // HTTP 상태 코드 값
+  private final int status;
+
+  // 에러 코드 Enum 이름 (e.g. NOT_FOUND, FORBIDDEN)
+  private final String code;
+
+  // 클라이언트용 상세 메시지
+  private final String message;
+
+  /**
+   * ErrorCode 기반으로 ErrorResponse를 생성하는 유틸 메서드
+   */
+  public static ErrorResponse from(ErrorCode errorCode) {
+    return ErrorResponse.of(
+            errorCode.getStatus().value(),
+            errorCode.name(),
+            errorCode.getMessage()
+    );
+  }
+
+  /**
+   * ErrorCode + 사용자 정의 메시지를 함께 사용하는 메서드
+   */
+  public static ErrorResponse from(ErrorCode errorCode, String detailMessage) {
+    return ErrorResponse.of(
+            errorCode.getStatus().value(),
+            errorCode.name(),
+            detailMessage
+    );
+  }
+}


### PR DESCRIPTION
## 📌 개요
- 공통 예외 처리 및 각 도메인 별 예외 처리를 위해 전역적으로 처리할 수 있는 ExceptionHandler를 구현함.

## 🚀 관련 이슈
- #21 

## ✅ 변경 사항
* 도메인 예외 상태 정의 : ErrorCode 추가
* 일관된 예외 규격 : BusinessException 추가
* 에러 응답 포맷 통일 : ErrorResponse 추가
* 전역 예외 처리 : ExceptionHandler 추가

## 📝 상세 내용
- ErrorCode의 경우 현재 공통 예외에 대한 코드를 추가한 상태 
- - 에러 코드 작성 규칙이 필요할 것으로 보임. 컨벤션 갱신 예정
- ExceptionHandler에서 Valid 관련 예외 추가

## 📚 관련 문서
-
