### PR TITLE
Feature/coupon 쿠폰 도메인 개선

### DIFF
--- a/backend/src/main/java/groom/backend/application/coupon/CouponIssueService.java
+++ b/backend/src/main/java/groom/backend/application/coupon/CouponIssueService.java
@@ -44,7 +44,7 @@ public class CouponIssueService {
     // TODO : 쿠폰 만료일은 정책 관련 사항
     // coupon 만료일은 00:00을 기준으로 함. LocalDate는 시간이 존재하지 않으므로 생성 시 시간을 추가하여 생성
     CouponIssue couponIssue = couponIssueRepository.save(CouponIssue.builder()
-            .couponId(couponId)
+            .coupon(coupon)
             .userId(user.getId())
             .createdAt(LocalDateTime.now())
             .deletedAt(LocalDateTime.of(coupon.getExpireDate(), LocalTime.MIN))

--- a/backend/src/main/java/groom/backend/application/coupon/CouponIssueService.java
+++ b/backend/src/main/java/groom/backend/application/coupon/CouponIssueService.java
@@ -27,7 +27,8 @@ public class CouponIssueService {
   @Transactional
   public CouponIssueResponse issueCoupon(Long couponId, User user) {
     // 쿠폰 조회
-    Coupon coupon = couponRepository.findById(couponId).orElseThrow(
+    // 비관적 락을 이용해 리소스 점유, 자원 충돌 ( quantity <= 0 ) 케이스 방지
+    Coupon coupon = couponRepository.findByIdForUpdate(couponId).orElseThrow(
             ()-> new BusinessException(ErrorCode.NOT_FOUND)
     );
 
@@ -42,7 +43,7 @@ public class CouponIssueService {
     }
 
     // 쿠폰 확보
-    // TODO : 동시성 이슈 발생 가능
+    // 분산 아키텍처에서는 여전히 동시성 문제 발생 가능
     coupon.decreaseQuantity();
 
     // 쿠폰 등록 및 DB 적용

--- a/backend/src/main/java/groom/backend/application/coupon/CouponIssueService.java
+++ b/backend/src/main/java/groom/backend/application/coupon/CouponIssueService.java
@@ -1,0 +1,64 @@
+package groom.backend.application.coupon;
+
+import groom.backend.domain.auth.entity.User;
+import groom.backend.domain.coupon.entity.Coupon;
+import groom.backend.domain.coupon.entity.CouponIssue;
+import groom.backend.domain.coupon.repository.CouponIssueRepository;
+import groom.backend.domain.coupon.repository.CouponRepository;
+import groom.backend.interfaces.coupon.dto.response.CouponIssueResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CouponIssueService {
+  private final CouponRepository couponRepository;
+  private final CouponIssueRepository  couponIssueRepository;
+
+  @Transactional
+  public CouponIssueResponse issueCoupon(Long couponId, User user) {
+    // 쿠폰 조회
+    Coupon coupon = couponRepository.findById(couponId).orElse(null);
+
+    if (coupon == null) {
+      return null;
+    }
+
+    // 활성화 여부 확인
+    // TODO : 비활성화 상태일 시 404 Not Found Exception 발생
+
+    // 수량 확인
+    // TODO : 수량이 0보다 낮거나 같은 경우 409 Conflict 발생 및 재고 소진 메시지 반환
+
+    // 쿠폰 확보
+    coupon.decreaseQuantity();
+
+    // 쿠폰 등록 및 DB 적용
+    // TODO : 쿠폰 만료일은 정책 관련 사항
+    // coupon 만료일은 00:00을 기준으로 함. LocalDate는 시간이 존재하지 않으므로 생성 시 시간을 추가하여 생성
+    CouponIssue couponIssue = couponIssueRepository.save(CouponIssue.builder()
+            .couponId(couponId)
+            .userId(user.getId())
+            .createdAt(LocalDateTime.now())
+            .deletedAt(LocalDateTime.of(coupon.getExpireDate(), LocalTime.MIN))
+            .build());
+    couponRepository.save(coupon);
+
+
+    // 확보된 쿠폰 반환
+    return CouponIssueResponse.from(couponIssue);
+  }
+
+  public List<CouponIssueResponse> searchMyCoupon(Long userId) {
+    // 유저 id로 쿠폰 조회
+    // 현재 사용 가능한 (만료 시간, 활성화 여부) 쿠폰 조회
+    return couponIssueRepository.findByUserIdAndIsActiveTrueAndDeletedAtAfter(userId, LocalDateTime.now()).stream().map(CouponIssueResponse::from).collect(Collectors.toList());
+  }
+}

--- a/backend/src/main/java/groom/backend/application/coupon/CouponService.java
+++ b/backend/src/main/java/groom/backend/application/coupon/CouponService.java
@@ -1,5 +1,7 @@
 package groom.backend.application.coupon;
 
+import groom.backend.common.exception.BusinessException;
+import groom.backend.common.exception.ErrorCode;
 import groom.backend.interfaces.coupon.dto.request.CouponCreateRequest;
 import groom.backend.interfaces.coupon.dto.request.CouponSearchCondition;
 import groom.backend.interfaces.coupon.dto.request.CouponUpdateRequest;
@@ -31,11 +33,9 @@ public class CouponService {
 
   public CouponResponse findCoupon(Long couponId) {
     // 단일 쿠폰 검색
-    Coupon coupon = couponRepository.findById(couponId).orElse(null);
-
-    if (coupon == null) {
-      return null;
-    }
+    Coupon coupon = couponRepository.findById(couponId).orElseThrow(
+            ()-> new BusinessException(ErrorCode.NOT_FOUND)
+    );
 
     // 검색 결과 반환
     return CouponResponse.from(coupon);
@@ -51,11 +51,9 @@ public class CouponService {
   @Transactional
   public CouponResponse updateCoupon(Long couponId, CouponUpdateRequest couponUpdateRequest) {
     // coupon id 기반 조회
-    Coupon currentCoupon = couponRepository.findById(couponId).orElse(null);
-
-    if (currentCoupon == null) {
-      return null;
-    }
+    Coupon currentCoupon = couponRepository.findById(couponId).orElseThrow(
+            ()-> new BusinessException(ErrorCode.NOT_FOUND)
+    );
 
     // 쿠폰 수정
     currentCoupon.update(couponUpdateRequest);

--- a/backend/src/main/java/groom/backend/application/coupon/CouponService.java
+++ b/backend/src/main/java/groom/backend/application/coupon/CouponService.java
@@ -1,6 +1,5 @@
 package groom.backend.application.coupon;
 
-import groom.backend.domain.auth.entity.User;
 import groom.backend.interfaces.coupon.dto.request.CouponCreateRequest;
 import groom.backend.interfaces.coupon.dto.request.CouponSearchCondition;
 import groom.backend.interfaces.coupon.dto.request.CouponUpdateRequest;
@@ -12,11 +11,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor

--- a/backend/src/main/java/groom/backend/application/coupon/CouponService.java
+++ b/backend/src/main/java/groom/backend/application/coupon/CouponService.java
@@ -1,14 +1,11 @@
 package groom.backend.application.coupon;
 
 import groom.backend.domain.auth.entity.User;
-import groom.backend.domain.coupon.entity.CouponIssue;
 import groom.backend.interfaces.coupon.dto.request.CouponCreateRequest;
 import groom.backend.interfaces.coupon.dto.request.CouponSearchCondition;
 import groom.backend.interfaces.coupon.dto.request.CouponUpdateRequest;
-import groom.backend.interfaces.coupon.dto.response.CouponIssueResponse;
 import groom.backend.interfaces.coupon.dto.response.CouponResponse;
 import groom.backend.domain.coupon.entity.Coupon;
-import groom.backend.domain.coupon.repository.CouponIssueRepository;
 import groom.backend.domain.coupon.repository.CouponRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -26,47 +23,7 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class CouponService {
   private final CouponRepository couponRepository;
-  private final CouponIssueRepository couponIssueRepository;
 
-  @Transactional
-  public CouponIssueResponse issueCoupon(Long couponId, User user) {
-    // 쿠폰 조회
-    Coupon coupon = couponRepository.findById(couponId).orElse(null);
-
-    if (coupon == null) {
-      return null;
-    }
-
-    // 활성화 여부 확인
-    // TODO : 비활성화 상태일 시 404 Not Found Exception 발생
-
-    // 수량 확인
-    // TODO : 수량이 0보다 낮거나 같은 경우 409 Conflict 발생 및 재고 소진 메시지 반환
-
-    // 쿠폰 확보
-    coupon.decreaseQuantity();
-
-    // 쿠폰 등록 및 DB 적용
-    // TODO : 쿠폰 만료일은 정책 관련 사항
-    // coupon 만료일은 00:00을 기준으로 함. LocalDate는 시간이 존재하지 않으므로 생성 시 시간을 추가하여 생성
-    CouponIssue couponIssue = couponIssueRepository.save(CouponIssue.builder()
-                    .couponId(couponId)
-                    .userId(user.getId())
-                    .createdAt(LocalDateTime.now())
-                    .deletedAt(LocalDateTime.of(coupon.getExpireDate(), LocalTime.MIN))
-            .build());
-    couponRepository.save(coupon);
-
-
-    // 확보된 쿠폰 반환
-    return CouponIssueResponse.from(couponIssue);
-  }
-
-  public List<CouponIssueResponse> searchMyCoupon(Long userId) {
-    // 유저 id로 쿠폰 조회
-    // 현재 사용 가능한 (만료 시간, 활성화 여부) 쿠폰 조회
-    return couponIssueRepository.findByUserIdAndIsActiveTrueAndDeletedAtAfter(userId, LocalDateTime.now()).stream().map(CouponIssueResponse::from).collect(Collectors.toList());
-  }
 
   @Transactional
   public CouponResponse createCoupon(CouponCreateRequest couponCreateRequest) {

--- a/backend/src/main/java/groom/backend/application/coupon/CouponService.java
+++ b/backend/src/main/java/groom/backend/application/coupon/CouponService.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -22,10 +23,12 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class CouponService {
   private final CouponRepository couponRepository;
   private final CouponIssueRepository couponIssueRepository;
 
+  @Transactional
   public CouponIssueResponse issueCoupon(Long couponId, User user) {
     // 쿠폰 조회
     Coupon coupon = couponRepository.findById(couponId).orElse(null);
@@ -65,6 +68,7 @@ public class CouponService {
     return couponIssueRepository.findByUserIdAndIsActiveTrueAndDeletedAtAfter(userId, LocalDateTime.now()).stream().map(CouponIssueResponse::from).collect(Collectors.toList());
   }
 
+  @Transactional
   public CouponResponse createCoupon(CouponCreateRequest couponCreateRequest) {
     // dto를 entity로 변환
     Coupon coupon = couponCreateRequest.toEntity();
@@ -93,6 +97,7 @@ public class CouponService {
             .map(CouponResponse::from);
   }
 
+  @Transactional
   public CouponResponse updateCoupon(Long couponId, CouponUpdateRequest couponUpdateRequest) {
     // coupon id 기반 조회
     Coupon currentCoupon = couponRepository.findById(couponId).orElse(null);
@@ -112,6 +117,7 @@ public class CouponService {
     return CouponResponse.from(currentCoupon);
   }
 
+  @Transactional
   public Boolean deleteCoupon(Long couponId) {
     // 쿠폰 삭제
     couponRepository.deleteById(couponId);

--- a/backend/src/main/java/groom/backend/domain/coupon/entity/CouponIssue.java
+++ b/backend/src/main/java/groom/backend/domain/coupon/entity/CouponIssue.java
@@ -1,9 +1,6 @@
 package groom.backend.domain.coupon.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -29,7 +26,7 @@ public class CouponIssue {
   private LocalDateTime deletedAt;
 
 
-  // coupon 1 : coupon issue N
+//  coupon 1 : coupon issue N
 //  @ManyToOne(fetch = FetchType.LAZY)
 //  @JoinColumn(name = "user_id", nullable = false)
 //  private User user;
@@ -37,8 +34,7 @@ public class CouponIssue {
 
 
   // coupon 1 : coupon issue N
-//  @ManyToOne(fetch = FetchType.LAZY)
-//  @JoinColumn(name = "coupon_id", nullable = false)
-//  private Coupon coupon;
-  private Long couponId;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "coupon_id", nullable = false)
+  private Coupon coupon;
 }

--- a/backend/src/main/java/groom/backend/domain/coupon/repository/CouponRepository.java
+++ b/backend/src/main/java/groom/backend/domain/coupon/repository/CouponRepository.java
@@ -2,6 +2,8 @@ package groom.backend.domain.coupon.repository;
 
 import groom.backend.interfaces.coupon.dto.request.CouponSearchCondition;
 import groom.backend.domain.coupon.entity.Coupon;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.repository.query.Param;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -9,8 +11,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface CouponRepository extends JpaRepository<Coupon, Long> {
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("SELECT c FROM Coupon c WHERE c.id = :couponId")
+  Optional<Coupon> findByIdForUpdate(@Param("couponId") Long couponId);
+
   @Query("""
   SELECT c
   FROM Coupon c

--- a/backend/src/main/java/groom/backend/interfaces/coupon/CouponController.java
+++ b/backend/src/main/java/groom/backend/interfaces/coupon/CouponController.java
@@ -3,7 +3,6 @@ package groom.backend.interfaces.coupon;
 import groom.backend.application.coupon.CouponIssueService;
 import groom.backend.application.coupon.CouponService;
 import groom.backend.domain.auth.entity.User;
-import groom.backend.infrastructure.security.CustomUserDetails;
 import groom.backend.interfaces.coupon.dto.request.CouponCreateRequest;
 import groom.backend.interfaces.coupon.dto.request.CouponSearchCondition;
 import groom.backend.interfaces.coupon.dto.request.CouponUpdateRequest;

--- a/backend/src/main/java/groom/backend/interfaces/coupon/CouponController.java
+++ b/backend/src/main/java/groom/backend/interfaces/coupon/CouponController.java
@@ -37,7 +37,7 @@ public class CouponController {
    * POST /coupon
    */
   @PostMapping
-  public ResponseEntity<CouponResponse> createCoupon(@RequestBody CouponCreateRequest request) {
+  public ResponseEntity<CouponResponse> createCoupon(@Validated @RequestBody CouponCreateRequest request) {
     CouponResponse response = couponService.createCoupon(request);
     return ResponseEntity.status(HttpStatus.CREATED).body(response);
   }

--- a/backend/src/main/java/groom/backend/interfaces/coupon/CouponController.java
+++ b/backend/src/main/java/groom/backend/interfaces/coupon/CouponController.java
@@ -1,5 +1,6 @@
 package groom.backend.interfaces.coupon;
 
+import groom.backend.application.coupon.CouponIssueService;
 import groom.backend.application.coupon.CouponService;
 import groom.backend.domain.auth.entity.User;
 import groom.backend.infrastructure.security.CustomUserDetails;
@@ -30,6 +31,8 @@ import java.util.List;
 @RequestMapping("/coupon")
 public class CouponController {
   private final CouponService couponService;
+  private final CouponIssueService couponIssueService;
+
   /**
    * 쿠폰 생성
    * POST /coupon
@@ -122,7 +125,7 @@ public class CouponController {
     }
 
     // 쿠폰 발급
-    CouponIssueResponse response = couponService.issueCoupon(couponId, user);
+    CouponIssueResponse response = couponIssueService.issueCoupon(couponId, user);
 
     // 쿠폰이 존재하지 않을 시
     if (response == null) {
@@ -145,7 +148,7 @@ public class CouponController {
     Long userId = user.getId();
 
     // 내 미사용 쿠폰 조회
-    List<CouponIssueResponse> response = couponService.searchMyCoupon(userId);
+    List<CouponIssueResponse> response = couponIssueService.searchMyCoupon(userId);
 
     return ResponseEntity.ok(response);
   }

--- a/backend/src/main/java/groom/backend/interfaces/coupon/dto/request/CouponCreateRequest.java
+++ b/backend/src/main/java/groom/backend/interfaces/coupon/dto/request/CouponCreateRequest.java
@@ -2,6 +2,7 @@ package groom.backend.interfaces.coupon.dto.request;
 
 import groom.backend.domain.coupon.entity.Coupon;
 import groom.backend.domain.coupon.enums.CouponType;
+import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 
 import java.time.LocalDate;
@@ -12,17 +13,21 @@ import java.time.LocalDate;
 @ToString
 @Builder
 public class CouponCreateRequest {
-
+  @NotBlank
   private String name;
 
   private String description;
 
+  @NotBlank
   private Long quantity;
 
+  @NotBlank
   private Integer amount;
 
+  @NotBlank
   private CouponType type;
 
+  @NotBlank
   private LocalDate expireDate;
 
   public Coupon toEntity() {

--- a/backend/src/main/java/groom/backend/interfaces/coupon/dto/request/CouponCreateRequest.java
+++ b/backend/src/main/java/groom/backend/interfaces/coupon/dto/request/CouponCreateRequest.java
@@ -2,8 +2,6 @@ package groom.backend.interfaces.coupon.dto.request;
 
 import groom.backend.domain.coupon.entity.Coupon;
 import groom.backend.domain.coupon.enums.CouponType;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import lombok.*;
 
 import java.time.LocalDate;

--- a/backend/src/main/java/groom/backend/interfaces/coupon/dto/request/CouponCreateRequest.java
+++ b/backend/src/main/java/groom/backend/interfaces/coupon/dto/request/CouponCreateRequest.java
@@ -18,16 +18,16 @@ public class CouponCreateRequest {
 
   private String description;
 
-  @NotBlank
+  @NotNull
   private Long quantity;
 
-  @NotBlank
+  @NotNull
   private Integer amount;
 
-  @NotBlank
+  @NotNull
   private CouponType type;
 
-  @NotBlank
+  @NotNull
   private LocalDate expireDate;
 
   public Coupon toEntity() {

--- a/backend/src/main/java/groom/backend/interfaces/coupon/dto/request/CouponUpdateRequest.java
+++ b/backend/src/main/java/groom/backend/interfaces/coupon/dto/request/CouponUpdateRequest.java
@@ -1,6 +1,5 @@
 package groom.backend.interfaces.coupon.dto.request;
 
-import groom.backend.domain.coupon.enums.CouponType;
 import lombok.*;
 
 import java.time.LocalDate;

--- a/backend/src/main/java/groom/backend/interfaces/coupon/dto/response/CouponIssueResponse.java
+++ b/backend/src/main/java/groom/backend/interfaces/coupon/dto/response/CouponIssueResponse.java
@@ -3,7 +3,6 @@ package groom.backend.interfaces.coupon.dto.response;
 import groom.backend.domain.coupon.entity.CouponIssue;
 import lombok.*;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @NoArgsConstructor

--- a/backend/src/main/java/groom/backend/interfaces/coupon/dto/response/CouponIssueResponse.java
+++ b/backend/src/main/java/groom/backend/interfaces/coupon/dto/response/CouponIssueResponse.java
@@ -18,7 +18,7 @@ public class CouponIssueResponse {
 
   public static CouponIssueResponse from(CouponIssue couponIssue) {
     return CouponIssueResponse.builder()
-            .couponId(couponIssue.getCouponId())
+            .couponId(couponIssue.getCoupon().getId())
             .couponIssueId(couponIssue.getId())
             .createdAt(couponIssue.getCreatedAt())
             .deletedAt(couponIssue.getDeletedAt())


### PR DESCRIPTION
## 📌 개요
- 동시 발급 시 재고 충돌 방지 및 예외 처리 적용 등 쿠폰 도메인의 기능 개선

## 🚀 관련 이슈
- #20 

## ✅ 변경 사항
- 쿠폰 서비스 레이어 기능 개선
- 코드 개선

## 📝 상세 내용
- 쿠폰 발급 메서드 로킹 기법을 이용한 동시 발급 시 재고 충돌 방지
- Transactional 설정을 통해 예외 발생 시 일관성 보장
- SRP 준수를 위한 쿠폰 서비스 / 쿠폰 발급 서비스로 클래스 분리
- JPA 표준에 맞게 쿠폰 발급 엔티티의 FK 필드를 연관 관계 객체로 수정
- 사용되지 않는 클래스 import 삭제
- DTO validation 추가
- 서비스 레이어 예외처리 적용

## 📚 관련 문서
-
