### PR TITLE
fix : 선언부, 호출부의 매개변수 상이하여 나는 컴파일 에러 해결

### DIFF
--- a/backend/src/main/java/groom/backend/interfaces/raffle/RaffleController.java
+++ b/backend/src/main/java/groom/backend/interfaces/raffle/RaffleController.java
@@ -70,7 +70,7 @@ public class RaffleController {
 
 // 인터페이스 계층에서 DTO -> 도메인 기준으로 변환
         RaffleSearchCriteria criteria = RaffleSearchMapper.toCriteria(cond);
-        Page<RaffleResponse> page = raffleApplicationService.searchRaffles(user, criteria, pageable);
+        Page<RaffleResponse> page = raffleApplicationService.searchRaffles(criteria, pageable);
         return ResponseEntity.ok(page);
     }
 
@@ -81,7 +81,7 @@ public class RaffleController {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
 
-        RaffleResponse response = raffleApplicationService.getRaffleDetails(user, raffleId);
+        RaffleResponse response = raffleApplicationService.getRaffleDetails(raffleId);
         return ResponseEntity.ok(response);
     }
 }


### PR DESCRIPTION
## 📌 개요
- 컴파일 에러 발생 하여 처리

## 🚀 관련 이슈
- #32 

## ✅ 변경 사항
- 선언부에서 제거든 파라미터 호출영역에서도 제거

## 📝 상세 내용
- 선언 영역에서 불필요한 파라미터 제거 후 호출영역을 제거하지 않고 방치 하여 컴파일 에러 발생 
- 호출 영역도 불필요한 파라미터 삭제 처리로 버그 해결
-

## 📚 관련 문서
-
