### PR TITLE
Feature/raffles 결제 완료 후 티켓 생성 프로세스 개발

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -41,6 +41,8 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation 'org.mockito:mockito-junit-jupiter:5.2.0'
+    testImplementation 'org.mockito:mockito-core:5.2.0'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/groom/backend/application/raffle/RaffleApplicationService.java
+++ b/backend/src/main/java/groom/backend/application/raffle/RaffleApplicationService.java
@@ -15,6 +15,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -113,6 +115,28 @@ public class RaffleApplicationService {
         }
 
         raffleRepository.deleteById(raffle.getRaffleId());
+    }
+
+    // 장바구니에서 결제 완료 후, 해당 상품이 속한 추첨 ID 조회
+    @Transactional
+    public Raffle findByRaffleProductId(String raffleProductId) {
+        return raffleRepository.findByRaffleProductId(raffleProductId)
+                .orElseThrow(() -> new IllegalStateException("해당 상품으로 등록된 추첨이 존재하지 않습니다."));
+    }
+
+    // 현재 응모 가능여부 체크
+    public void validateRaffleForEntry(Raffle raffle) {
+        if(raffle.getStatus() != RaffleStatus.ACTIVE) {
+            throw new IllegalStateException("현재 진행중인 추첨이 아닙니다.");
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        if (now.isBefore(raffle.getEntryStartAt())) {
+            throw new IllegalStateException("응모 기간이 아직 시작되지 않았습니다.");
+        }
+        if (now.isAfter(raffle.getEntryEndAt())) {
+            throw new IllegalStateException("응모 기간이 종료되었습니다.");
+        }
     }
 
 

--- a/backend/src/main/java/groom/backend/application/raffle/RaffleTicketAllocationService.java
+++ b/backend/src/main/java/groom/backend/application/raffle/RaffleTicketAllocationService.java
@@ -13,7 +13,7 @@ public class RaffleTicketAllocationService {
 
     @Transactional
     public Long allocateNextTicketNumber(Long raffleId) {
-        RaffleTicketCounterJpaEntity counter = counterRepo.findByRaffleIdForUpdate(raffleId)
+        RaffleTicketCounterJpaEntity counter = counterRepo.findFirstByRaffleIdForUpdate(raffleId)
                 .orElseGet(() -> new RaffleTicketCounterJpaEntity(raffleId, 0L));
         long next = counter.getCurrentValue() + 1;
         counter.setCurrentValue(next);

--- a/backend/src/main/java/groom/backend/application/raffle/RaffleTicketAllocationService.java
+++ b/backend/src/main/java/groom/backend/application/raffle/RaffleTicketAllocationService.java
@@ -1,0 +1,24 @@
+package groom.backend.application.raffle;
+
+import groom.backend.interfaces.raffle.persistence.Entity.RaffleTicketCounterJpaEntity;
+import groom.backend.interfaces.raffle.persistence.repository.springData.SpringDataRaffleTicketCounterRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RaffleTicketAllocationService {
+    private final SpringDataRaffleTicketCounterRepository counterRepo;
+
+    @Transactional
+    public Long allocateNextTicketNumber(Long raffleId) {
+        RaffleTicketCounterJpaEntity counter = counterRepo.findByRaffleIdForUpdate(raffleId)
+                .orElseGet(() -> new RaffleTicketCounterJpaEntity(raffleId, 0L));
+        long next = counter.getCurrentValue() + 1;
+        counter.setCurrentValue(next);
+        counterRepo.save(counter);
+        return next;
+    }
+
+}

--- a/backend/src/main/java/groom/backend/application/raffle/RaffleTicketApplicationService.java
+++ b/backend/src/main/java/groom/backend/application/raffle/RaffleTicketApplicationService.java
@@ -21,14 +21,16 @@ public class RaffleTicketApplicationService {
 
 
     // 현재 응모된 수량 구하기
-    public int getEntriedCount(Raffle raffle, User user) {
-        return raffleTicketRepo.findCountByRaffleIdAndUserId(raffle.getRaffleId(), user.getId());
+    public int getEntryCount(Raffle raffle, User user) {
+        return raffleTicketRepo.countByRaffleIdAndUserId(raffle.getRaffleId(), user.getId());
     }
 
-    // 응모 가능 한지 확인
-    public boolean isPossibleToEntry(Raffle raffle, User user, int additionalCount) {
-        int currentCount = getEntriedCount(raffle, user);
-        return (currentCount + additionalCount)  <= raffle.getMaxEntriesPerUser();
+    // 응모 한도 검증
+    public void validateUserEntryLimit(Raffle raffle, User user, int additionalCount) {
+        int currentCount = getEntryCount(raffle, user);
+        if((currentCount + additionalCount) > raffle.getMaxEntriesPerUser()) {
+            throw new IllegalArgumentException("응모 한도를 초과하였습니다.");
+        }
     }
 
     // 결제 완료 후 호출 - 티켓 생성

--- a/backend/src/main/java/groom/backend/application/raffle/RaffleTicketApplicationService.java
+++ b/backend/src/main/java/groom/backend/application/raffle/RaffleTicketApplicationService.java
@@ -1,0 +1,50 @@
+package groom.backend.application.raffle;
+
+import groom.backend.domain.auth.entity.User;
+import groom.backend.domain.raffle.entity.Raffle;
+import groom.backend.interfaces.raffle.persistence.Entity.RaffleTicketJpaEntity;
+import groom.backend.interfaces.raffle.persistence.repository.springData.SpringDataRaffleTicketCounterRepository;
+import groom.backend.interfaces.raffle.persistence.repository.springData.SpringDataRaffleTicketRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class RaffleTicketApplicationService {
+
+    private final RaffleTicketAllocationService allocationService;
+    private final SpringDataRaffleTicketRepository raffleTicketRepo;
+    private final SpringDataRaffleTicketCounterRepository counterRepo;
+
+
+    // 현재 응모된 수량 구하기
+    public int getEntriedCount(Raffle raffle, User user) {
+        return raffleTicketRepo.findCountByRaffleIdAndUserId(raffle.getRaffleId(), user.getId());
+    }
+
+    // 응모 가능 한지 확인
+    public boolean isPossibleToEntry(Raffle raffle, User user, int additionalCount) {
+        int currentCount = getEntriedCount(raffle, user);
+        return (currentCount + additionalCount)  <= raffle.getMaxEntriesPerUser();
+    }
+
+    // 결제 완료 후 호출 - 티켓 생성
+    @Transactional
+    public RaffleTicketJpaEntity createTicket(Raffle raffle, User user) {
+        // allocateNextTicketNumber 내부에서 PESSIMISTIC_WRITE로 카운터를 잠그고 증가시킴
+        Long ticketNumber = allocationService.allocateNextTicketNumber(raffle.getRaffleId());
+
+        RaffleTicketJpaEntity ticket = RaffleTicketJpaEntity.builder()
+                .raffleId(raffle.getRaffleId())
+                .userId(user.getId())
+                .ticketNumber(ticketNumber)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        return raffleTicketRepo.save(ticket);
+    }
+
+}

--- a/backend/src/main/java/groom/backend/domain/raffle/repository/RaffleRepository.java
+++ b/backend/src/main/java/groom/backend/domain/raffle/repository/RaffleRepository.java
@@ -15,4 +15,7 @@ public interface RaffleRepository {
 
     // 도메인 수준의 검색 기준을 사용하도록 변경
     Page<Raffle> search(RaffleSearchCriteria cond, Pageable pageable);
+
+    // 추첨용 상품으로 RaffleId 조회
+    Optional<Raffle> findByRaffleProductId(String raffleProductId);
 }

--- a/backend/src/main/java/groom/backend/domain/raffle/repository/RaffleTicketRepository.java
+++ b/backend/src/main/java/groom/backend/domain/raffle/repository/RaffleTicketRepository.java
@@ -5,6 +5,6 @@ import groom.backend.domain.raffle.entity.RaffleTicket;
 public interface RaffleTicketRepository {
     RaffleTicket save(RaffleTicket raffle);
 
-    int findCountByRaffleIdAndUserId(Long raffleId, Long userId);
+    int countByRaffleIdAndUserId(Long raffleId, Long userId);
 
 }

--- a/backend/src/main/java/groom/backend/domain/raffle/repository/RaffleTicketRepository.java
+++ b/backend/src/main/java/groom/backend/domain/raffle/repository/RaffleTicketRepository.java
@@ -1,4 +1,10 @@
 package groom.backend.domain.raffle.repository;
 
+import groom.backend.domain.raffle.entity.RaffleTicket;
+
 public interface RaffleTicketRepository {
+    RaffleTicket save(RaffleTicket raffle);
+
+    int findCountByRaffleIdAndUserId(Long raffleId, Long userId);
+
 }

--- a/backend/src/main/java/groom/backend/interfaces/raffle/persistence/Entity/RaffleJpaEntity.java
+++ b/backend/src/main/java/groom/backend/interfaces/raffle/persistence/Entity/RaffleJpaEntity.java
@@ -1,4 +1,4 @@
-package groom.backend.interfaces.raffle.persistence;
+package groom.backend.interfaces.raffle.persistence.Entity;
 
 import groom.backend.domain.raffle.enums.RaffleStatus;
 import jakarta.persistence.*;

--- a/backend/src/main/java/groom/backend/interfaces/raffle/persistence/Entity/RaffleTicketCounterJpaEntity.java
+++ b/backend/src/main/java/groom/backend/interfaces/raffle/persistence/Entity/RaffleTicketCounterJpaEntity.java
@@ -1,0 +1,20 @@
+package groom.backend.interfaces.raffle.persistence.Entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.*;
+
+@Entity
+@Table(name = "raffle_ticket_counters")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RaffleTicketCounterJpaEntity {
+    @Id
+    private Long raffleId;
+    private Long currentValue;
+
+}

--- a/backend/src/main/java/groom/backend/interfaces/raffle/persistence/Entity/RaffleTicketJpaEntity.java
+++ b/backend/src/main/java/groom/backend/interfaces/raffle/persistence/Entity/RaffleTicketJpaEntity.java
@@ -6,7 +6,8 @@ import lombok.*;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "raffle_tickets")
+@Table(name = "raffle_tickets",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"raffle_id", "ticket_number"}))
 @Getter
 @Setter
 @NoArgsConstructor

--- a/backend/src/main/java/groom/backend/interfaces/raffle/persistence/Entity/RaffleTicketJpaEntity.java
+++ b/backend/src/main/java/groom/backend/interfaces/raffle/persistence/Entity/RaffleTicketJpaEntity.java
@@ -1,4 +1,4 @@
-package groom.backend.interfaces.raffle.persistence;
+package groom.backend.interfaces.raffle.persistence.Entity;
 
 import jakarta.persistence.*;
 import lombok.*;

--- a/backend/src/main/java/groom/backend/interfaces/raffle/persistence/Entity/RaffleWinnerJpaEntity.java
+++ b/backend/src/main/java/groom/backend/interfaces/raffle/persistence/Entity/RaffleWinnerJpaEntity.java
@@ -1,4 +1,4 @@
-package groom.backend.interfaces.raffle.persistence;
+package groom.backend.interfaces.raffle.persistence.Entity;
 
 import groom.backend.domain.raffle.enums.RaffleWinnerStatus;
 import jakarta.persistence.*;

--- a/backend/src/main/java/groom/backend/interfaces/raffle/persistence/JpaRaffleTicketRepository.java
+++ b/backend/src/main/java/groom/backend/interfaces/raffle/persistence/JpaRaffleTicketRepository.java
@@ -1,4 +1,0 @@
-package groom.backend.interfaces.raffle.persistence;
-
-public class JpaRaffleTicketRepository {
-}

--- a/backend/src/main/java/groom/backend/interfaces/raffle/persistence/JpaRaffleWinnerRepository.java
+++ b/backend/src/main/java/groom/backend/interfaces/raffle/persistence/JpaRaffleWinnerRepository.java
@@ -1,4 +1,0 @@
-package groom.backend.interfaces.raffle.persistence;
-
-public class JpaRaffleWinnerRepository {
-}

--- a/backend/src/main/java/groom/backend/interfaces/raffle/persistence/SpringDataRaffleTicketRepository.java
+++ b/backend/src/main/java/groom/backend/interfaces/raffle/persistence/SpringDataRaffleTicketRepository.java
@@ -1,4 +1,0 @@
-package groom.backend.interfaces.raffle.persistence;
-
-public interface SpringDataRaffleTicketRepository {
-}

--- a/backend/src/main/java/groom/backend/interfaces/raffle/persistence/SpringDataRaffleWinnerRepository.java
+++ b/backend/src/main/java/groom/backend/interfaces/raffle/persistence/SpringDataRaffleWinnerRepository.java
@@ -1,4 +1,0 @@
-package groom.backend.interfaces.raffle.persistence;
-
-public interface SpringDataRaffleWinnerRepository {
-}

--- a/backend/src/main/java/groom/backend/interfaces/raffle/persistence/repository/jpa/JpaRaffleRepository.java
+++ b/backend/src/main/java/groom/backend/interfaces/raffle/persistence/repository/jpa/JpaRaffleRepository.java
@@ -1,8 +1,10 @@
-package groom.backend.interfaces.raffle.persistence;
+package groom.backend.interfaces.raffle.persistence.repository.jpa;
 
 import groom.backend.domain.raffle.criteria.RaffleSearchCriteria;
 import groom.backend.domain.raffle.entity.Raffle;
 import groom.backend.domain.raffle.repository.RaffleRepository;
+import groom.backend.interfaces.raffle.persistence.Entity.RaffleJpaEntity;
+import groom.backend.interfaces.raffle.persistence.repository.springData.SpringDataRaffleRepository;
 import jakarta.persistence.criteria.Predicate;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;

--- a/backend/src/main/java/groom/backend/interfaces/raffle/persistence/repository/jpa/JpaRaffleRepository.java
+++ b/backend/src/main/java/groom/backend/interfaces/raffle/persistence/repository/jpa/JpaRaffleRepository.java
@@ -93,6 +93,12 @@ public class JpaRaffleRepository implements RaffleRepository {
         return new PageImpl<>(domainList, pageable, page.getTotalElements());
     }
 
+    // 추첨용 상품 Id 로 추첨 정보 받아오기
+    @Override
+    public Optional<Raffle> findByRaffleProductId(String raffleProductId) {
+        return raffleRepository.findByRaffleProductId(raffleProductId);
+    }
+
     // 도메인 기준을 Specification으로 변환 (인터페이스 레이어에 위치하므로 엔티티 참조 가능)
     private Specification<RaffleJpaEntity> toSpecification(RaffleSearchCriteria cond) {
         return (root, query, cb) -> {

--- a/backend/src/main/java/groom/backend/interfaces/raffle/persistence/repository/jpa/JpaRaffleTicketRepository.java
+++ b/backend/src/main/java/groom/backend/interfaces/raffle/persistence/repository/jpa/JpaRaffleTicketRepository.java
@@ -1,0 +1,45 @@
+package groom.backend.interfaces.raffle.persistence.repository.jpa;
+
+import groom.backend.domain.raffle.entity.RaffleTicket;
+import groom.backend.domain.raffle.repository.RaffleTicketRepository;
+import groom.backend.interfaces.raffle.persistence.Entity.RaffleTicketJpaEntity;
+import groom.backend.interfaces.raffle.persistence.repository.springData.SpringDataRaffleTicketRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class JpaRaffleTicketRepository implements RaffleTicketRepository {
+    private final SpringDataRaffleTicketRepository ticketRepository;
+
+    public JpaRaffleTicketRepository(SpringDataRaffleTicketRepository ticketRepository) {
+        this.ticketRepository = ticketRepository;
+    }
+
+    @Override
+    public RaffleTicket save(RaffleTicket ticket) {
+        RaffleTicketJpaEntity saved = ticketRepository.save(toEntity(ticket));
+        return toDomain(saved);
+    }
+
+    @Override
+    public int findCountByRaffleIdAndUserId(Long raffleId, Long userId) {
+        return ticketRepository.findCountByRaffleIdAndUserId(raffleId, userId);
+    }
+
+    private RaffleTicket toDomain(RaffleTicketJpaEntity e) {
+        return new RaffleTicket(e.getRaffleTicketId(),
+                e.getTicketNumber(),
+                e.getRaffleId(),
+                e.getUserId(),
+                e.getCreatedAt()
+        );
+    }
+
+    private RaffleTicketJpaEntity toEntity(RaffleTicket raffle) {
+        return RaffleTicketJpaEntity.builder()
+                .raffleId(raffle.getRaffleId())
+                .raffleTicketId(raffle.getRaffleTicketId())
+                .ticketNumber(raffle.getTicketNumber())
+                .createdAt(raffle.getCreatedAt())
+                .build();
+    }
+}

--- a/backend/src/main/java/groom/backend/interfaces/raffle/persistence/repository/jpa/JpaRaffleTicketRepository.java
+++ b/backend/src/main/java/groom/backend/interfaces/raffle/persistence/repository/jpa/JpaRaffleTicketRepository.java
@@ -21,8 +21,8 @@ public class JpaRaffleTicketRepository implements RaffleTicketRepository {
     }
 
     @Override
-    public int findCountByRaffleIdAndUserId(Long raffleId, Long userId) {
-        return ticketRepository.findCountByRaffleIdAndUserId(raffleId, userId);
+    public int countByRaffleIdAndUserId(Long raffleId, Long userId) {
+        return ticketRepository.countByRaffleIdAndUserId(raffleId, userId);
     }
 
     private RaffleTicket toDomain(RaffleTicketJpaEntity e) {

--- a/backend/src/main/java/groom/backend/interfaces/raffle/persistence/repository/jpa/JpaRaffleWinnerRepository.java
+++ b/backend/src/main/java/groom/backend/interfaces/raffle/persistence/repository/jpa/JpaRaffleWinnerRepository.java
@@ -1,0 +1,8 @@
+package groom.backend.interfaces.raffle.persistence.repository.jpa;
+
+import groom.backend.domain.raffle.repository.RaffleWinnerRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class JpaRaffleWinnerRepository implements RaffleWinnerRepository {
+}

--- a/backend/src/main/java/groom/backend/interfaces/raffle/persistence/repository/springData/SpringDataRaffleRepository.java
+++ b/backend/src/main/java/groom/backend/interfaces/raffle/persistence/repository/springData/SpringDataRaffleRepository.java
@@ -1,5 +1,7 @@
-package groom.backend.interfaces.raffle.persistence;
+package groom.backend.interfaces.raffle.persistence.repository.springData;
 
+import groom.backend.domain.raffle.entity.Raffle;
+import groom.backend.interfaces.raffle.persistence.Entity.RaffleJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 

--- a/backend/src/main/java/groom/backend/interfaces/raffle/persistence/repository/springData/SpringDataRaffleRepository.java
+++ b/backend/src/main/java/groom/backend/interfaces/raffle/persistence/repository/springData/SpringDataRaffleRepository.java
@@ -5,6 +5,10 @@ import groom.backend.interfaces.raffle.persistence.Entity.RaffleJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
+import java.util.Optional;
+
 public interface SpringDataRaffleRepository extends JpaRepository<RaffleJpaEntity, Long>, JpaSpecificationExecutor<RaffleJpaEntity> {
     boolean existsByRaffleProductId(String raffleProductId);
+
+    Optional<Raffle> findByRaffleProductId(String raffleProductId);
 }

--- a/backend/src/main/java/groom/backend/interfaces/raffle/persistence/repository/springData/SpringDataRaffleTicketCounterRepository.java
+++ b/backend/src/main/java/groom/backend/interfaces/raffle/persistence/repository/springData/SpringDataRaffleTicketCounterRepository.java
@@ -1,0 +1,19 @@
+package groom.backend.interfaces.raffle.persistence.repository.springData;
+
+import groom.backend.interfaces.raffle.persistence.Entity.RaffleTicketCounterJpaEntity;
+import io.lettuce.core.dynamic.annotation.Param;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface SpringDataRaffleTicketCounterRepository extends JpaRepository<RaffleTicketCounterJpaEntity, Long> {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select c from RaffleTicketCounterJpaEntity c where c.raffleId = :raffleId")
+    Optional<RaffleTicketCounterJpaEntity> findByRaffleIdForUpdate(@Param("raffleId") Long raffleId);
+
+}

--- a/backend/src/main/java/groom/backend/interfaces/raffle/persistence/repository/springData/SpringDataRaffleTicketCounterRepository.java
+++ b/backend/src/main/java/groom/backend/interfaces/raffle/persistence/repository/springData/SpringDataRaffleTicketCounterRepository.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 @Repository
 public interface SpringDataRaffleTicketCounterRepository extends JpaRepository<RaffleTicketCounterJpaEntity, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("select c from RaffleTicketCounterJpaEntity c where c.raffleId = :raffleId")
-    Optional<RaffleTicketCounterJpaEntity> findByRaffleIdForUpdate(@Param("raffleId") Long raffleId);
+    @Query("select c from RaffleTicketCounterJpaEntity c where c.raffleId = :raffleId order by c.currentValue desc")
+    Optional<RaffleTicketCounterJpaEntity> findFirstByRaffleIdForUpdate(@Param("raffleId") Long raffleId);
 
 }

--- a/backend/src/main/java/groom/backend/interfaces/raffle/persistence/repository/springData/SpringDataRaffleTicketRepository.java
+++ b/backend/src/main/java/groom/backend/interfaces/raffle/persistence/repository/springData/SpringDataRaffleTicketRepository.java
@@ -4,5 +4,5 @@ import groom.backend.interfaces.raffle.persistence.Entity.RaffleTicketJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SpringDataRaffleTicketRepository extends JpaRepository<RaffleTicketJpaEntity, Long> {
-    int findCountByRaffleIdAndUserId(Long raffleId, Long userId);
+    int countByRaffleIdAndUserId(Long raffleId, Long userId);
 }

--- a/backend/src/main/java/groom/backend/interfaces/raffle/persistence/repository/springData/SpringDataRaffleTicketRepository.java
+++ b/backend/src/main/java/groom/backend/interfaces/raffle/persistence/repository/springData/SpringDataRaffleTicketRepository.java
@@ -1,0 +1,8 @@
+package groom.backend.interfaces.raffle.persistence.repository.springData;
+
+import groom.backend.interfaces.raffle.persistence.Entity.RaffleTicketJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SpringDataRaffleTicketRepository extends JpaRepository<RaffleTicketJpaEntity, Long> {
+    int findCountByRaffleIdAndUserId(Long raffleId, Long userId);
+}

--- a/backend/src/main/java/groom/backend/interfaces/raffle/persistence/repository/springData/SpringDataRaffleWinnerRepository.java
+++ b/backend/src/main/java/groom/backend/interfaces/raffle/persistence/repository/springData/SpringDataRaffleWinnerRepository.java
@@ -1,0 +1,8 @@
+package groom.backend.interfaces.raffle.persistence.repository.springData;
+
+import groom.backend.interfaces.raffle.persistence.Entity.RaffleWinnerJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface SpringDataRaffleWinnerRepository extends JpaRepository<RaffleWinnerJpaEntity, Long> {
+}

--- a/backend/src/test/java/groom/backend/application/raffle/RaffleTicketApplicationServiceCreateTicketTest.java
+++ b/backend/src/test/java/groom/backend/application/raffle/RaffleTicketApplicationServiceCreateTicketTest.java
@@ -1,0 +1,95 @@
+package groom.backend.application.raffle;
+
+import groom.backend.domain.auth.entity.User;
+import groom.backend.domain.raffle.entity.Raffle;
+import groom.backend.interfaces.raffle.persistence.Entity.RaffleTicketJpaEntity;
+import groom.backend.interfaces.raffle.persistence.repository.springData.SpringDataRaffleTicketRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+
+@Transactional
+@SpringBootTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class RaffleTicketApplicationServiceCreateTicketTest {
+
+    @Autowired
+    private RaffleTicketAllocationService allocationService;
+
+    @Autowired
+    private RaffleTicketApplicationService raffleTicketService;
+
+    @Autowired
+    private SpringDataRaffleTicketRepository raffleTicketRepo;
+
+    @Autowired
+    private RaffleApplicationService raffleApplicationService;
+
+
+    @Test
+    void createTicket_savesToDatabase_realDb() {
+        Raffle raffle = mock(Raffle.class);
+        User user = mock(User.class);
+
+        given(raffle.getRaffleId()).willReturn(1L);
+        given(user.getId()).willReturn(1L);
+
+        Raffle findRaffle = raffleApplicationService.findByRaffleProductId("4");
+
+        raffleApplicationService.validateRaffleForEntry(findRaffle);
+
+        raffleTicketService.validateUserEntryLimit(findRaffle, user, 1);
+
+        raffleTicketService.createTicket(findRaffle, user);
+
+        int count = raffleTicketRepo.findAll().size();
+
+        assertEquals(2, count);
+    }
+
+    @Test
+    void createTicket_allocatesNumberAndSavesTicket() {
+        //given
+        Raffle raffle = mock(Raffle.class); // Raffle 도메인 객체를 목으로 생성 — 필요한 메서드만 스텁할 예정
+        User user = mock(User.class); // User 도메인 객체를 목으로 생성
+
+        given(raffle.getRaffleId()).willReturn(10L);
+        given(user.getId()).willReturn(100L);
+
+        // allocationService에서 5L을 할당한다고 가정
+        given(allocationService.allocateNextTicketNumber(10L)).willReturn(5L);
+
+        // save는 전달된 엔티티를 그대로 반환
+        given(raffleTicketRepo.save(any(RaffleTicketJpaEntity.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        RaffleTicketJpaEntity result = raffleTicketService.createTicket(raffle, user);
+
+        // then
+        assertNotNull(result);
+        assertEquals(10L, result.getRaffleId());
+        assertEquals(100L, result.getUserId());
+        assertEquals(5L, result.getTicketNumber());
+        assertNotNull(result.getCreatedAt());
+        assertTrue(result.getCreatedAt().isBefore(LocalDateTime.now().plusSeconds(2)));
+
+        ArgumentCaptor<RaffleTicketJpaEntity> captor = ArgumentCaptor.forClass(RaffleTicketJpaEntity.class);
+        then(raffleTicketRepo).should().save(captor.capture());
+        RaffleTicketJpaEntity saved = captor.getValue();
+        assertEquals(5L, saved.getTicketNumber());
+        assertEquals(10L, saved.getRaffleId());
+        assertEquals(100L, saved.getUserId());
+
+        then(allocationService).should().allocateNextTicketNumber(10L);
+    }
+}


### PR DESCRIPTION
## 📌 개요
- 추첨 티켓을 결제 한 이후 검증을 거친 후 응모 한다.

## 🚀 관련 이슈
- close #15 

## ✅ 변경 사항
- raffle product 로 추첨 마스터 데이터 조회
- 추첨 마스터 데이터 검증
- 유저당 구매 가능 횟수 검증
- 티켓 생성 시 각 추첨 마다 티켓 번호 를 위해 카운터 테이블 생성
- 티켓 생성 로직

## 📝 상세 내용
상품ID으로 추첨 정보 조회
RaffleApplicationService.findByRaffleProductId(String raffleProductId)

추첨데이터의 상태 검증, 기간 검증, 수량 검증
RaffleApplicationService.validateRaffleForEntry(Raffle raffle)
RaffleTicketApplicationService.validateUserEntryLimit(Raffle raffle, User user, int additionalCount)

티켓 생성
RaffleTicketApplicationService.createTicket(Raffle raffle, User user)

## 📚 관련 문서
-
