### PR TITLE
Feature/raffles draw 추첨 결과 실행

### DIFF
--- a/backend/src/main/java/groom/backend/application/raffle/RaffleApplicationService.java
+++ b/backend/src/main/java/groom/backend/application/raffle/RaffleApplicationService.java
@@ -106,7 +106,7 @@ public class RaffleApplicationService {
 
     // 장바구니에서 결제 완료 후, 해당 상품이 속한 추첨 엔티티(Raffle)를 조회
     @Transactional
-    public Raffle findByRaffleProductId(String raffleProductId) {
+    public Raffle findByRaffleProductId(Long raffleProductId) {
         return raffleRepository.findByRaffleProductId(raffleProductId)
                 .orElseThrow(() -> new IllegalStateException("해당 상품으로 등록된 추첨이 존재하지 않습니다."));
     }

--- a/backend/src/main/java/groom/backend/application/raffle/RaffleDrawApplicationService.java
+++ b/backend/src/main/java/groom/backend/application/raffle/RaffleDrawApplicationService.java
@@ -1,0 +1,98 @@
+package groom.backend.application.raffle;
+
+import groom.backend.domain.auth.entity.User;
+import groom.backend.domain.raffle.entity.Raffle;
+import groom.backend.interfaces.raffle.dto.notification.RaffleWinnerNotification;
+import groom.backend.domain.raffle.enums.RaffleStatus;
+import groom.backend.domain.raffle.repository.RaffleRepository;
+import groom.backend.domain.raffle.repository.RaffleTicketRepository;
+import groom.backend.domain.raffle.repository.RaffleWinnerRepository;
+import groom.backend.interfaces.raffle.dto.request.RaffleDrawCondition;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RaffleDrawApplicationService {
+
+    private final RaffleValidationService validationService;
+    private final RaffleRepository raffleRepository;
+    private final RaffleWinnerRepository raffleWinnerRepo;
+    private final RaffleTicketRepository ticketRepository;
+
+    @Transactional
+    public void drawRaffleWinners(User user, Long raffleId) {
+        // 관리자 권한 검증
+        validationService.ensureAdmin(user);
+
+        // 추첨 존재 여부 및 상태 검증
+        Raffle raffle = raffleRepository.findById(raffleId)
+                            .orElseThrow(() -> new IllegalArgumentException("해당 ID의 추첨이 존재하지 않습니다."));
+
+        // 추첨 가능 상태 검증
+        validationService.validateRaffleForDraw(raffle);
+
+        // 실제 참가자 수 조회
+        int entryCount = ticketRepository.countDistinctUserByRaffleId(raffle.getRaffleId());
+
+        if (entryCount == 0) {
+            throw new IllegalStateException("응모자가 없어 당첨자 추첨을 진행할 수 없습니다.");
+        }
+
+        // 이미 추첨된 당첨자 수 조회
+        int currentWinnerCount = raffleWinnerRepo.countWinnerByRaffleId(raffle.getRaffleId());
+        int numberOfWinnersToDraw = (raffle.getWinnersCount() - currentWinnerCount);
+
+        if (numberOfWinnersToDraw <= 0) {
+            throw new IllegalStateException("이미 모든 당첨자가 추첨되었습니다.");
+        }
+
+        // 당첨자 추첨
+        RaffleDrawCondition condition = new RaffleDrawCondition();
+        condition.setRaffleId(raffle.getRaffleId());
+        condition.setNumberOfWinners(numberOfWinnersToDraw);
+        // Native Query를 사용한 당첨자 추첨
+        int result = raffleWinnerRepo.pickWinnersNative(condition);
+
+        // 추첨 결과 검증:
+        // 당첨자가 실제 참가자 수 보다 적거나 당첨자 수 보다 많으면 오류 처리
+        if(result < entryCount || result > raffle.getWinnersCount()) {
+            throw new IllegalStateException("당첨자 추첨에 실패했습니다. 다시 시도해주세요.");
+        }
+
+        // 추첨 결과 검증
+        // 당첨자 수가 설정된 당첨자 수보다 적으면 경고 로그 출력
+        if (result < raffle.getWinnersCount()) {
+            log.warn("Not enough winners were picked: expected {}, but got {}",
+                    raffle.getWinnersCount(), result);
+        }
+
+        // TODO : 상품 수량 차감
+
+        // 추첨 완료 후 추첨 상태 업데이트
+        raffle.updateStatus(RaffleStatus.DRAWN);
+        raffleRepository.save(raffle);
+    }
+
+    @Transactional
+    public void sendRaffleWinnersNotification(Long raffleId) {
+
+        Raffle raffle = raffleRepository.findById(raffleId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 ID의 추첨이 존재하지 않습니다."));
+
+        List<RaffleWinnerNotification> notifications = raffleWinnerRepo.findNotificationsByRaffleId(raffleId);
+
+        // TODO : 알림 전송 로직 구현
+        for (RaffleWinnerNotification notification : notifications) {
+            log.info("Sending notification to User ID {}: {}", notification.getUserId(), notification.getMessage());
+        }
+
+    }
+
+}

--- a/backend/src/main/java/groom/backend/application/raffle/RaffleDrawApplicationService.java
+++ b/backend/src/main/java/groom/backend/application/raffle/RaffleDrawApplicationService.java
@@ -61,10 +61,12 @@ public class RaffleDrawApplicationService {
         int result = raffleWinnerRepo.pickWinnersNative(condition);
 
         // 추첨 결과 검증:
-        // 당첨자가 실제 참가자 수 보다 적거나 당첨자 수 보다 많으면 오류 처리
-        if(result < entryCount || result > raffle.getWinnersCount()) {
+        // 결과값이 실제 응모자 수 또는 요청된 당첨자 수 중 작은 값과 일치하는지 확인
+        int expected = Math.min(entryCount, numberOfWinnersToDraw);
+        if (result != expected) {
             throw new IllegalStateException("당첨자 추첨에 실패했습니다. 다시 시도해주세요.");
         }
+
 
         // 추첨 결과 검증
         // 당첨자 수가 설정된 당첨자 수보다 적으면 경고 로그 출력

--- a/backend/src/main/java/groom/backend/application/raffle/RaffleTicketApplicationService.java
+++ b/backend/src/main/java/groom/backend/application/raffle/RaffleTicketApplicationService.java
@@ -3,6 +3,7 @@ package groom.backend.application.raffle;
 import groom.backend.domain.auth.entity.User;
 import groom.backend.domain.raffle.entity.Raffle;
 import groom.backend.domain.raffle.repository.RaffleRepository;
+import groom.backend.interfaces.raffle.persistence.Entity.RaffleJpaEntity;
 import groom.backend.interfaces.raffle.persistence.Entity.RaffleTicketJpaEntity;
 import groom.backend.interfaces.raffle.persistence.repository.springData.SpringDataRaffleTicketRepository;
 import lombok.RequiredArgsConstructor;
@@ -41,7 +42,7 @@ public class RaffleTicketApplicationService {
         Long ticketNumber = allocationService.allocateNextTicketNumber(raffle.getRaffleId());
 
         RaffleTicketJpaEntity ticket = RaffleTicketJpaEntity.builder()
-                .raffleId(raffle.getRaffleId())
+                .raffle(RaffleJpaEntity.from(raffle))
                 .userId(user.getId())
                 .ticketNumber(ticketNumber)
                 .createdAt(LocalDateTime.now())

--- a/backend/src/main/java/groom/backend/application/raffle/RaffleValidationService.java
+++ b/backend/src/main/java/groom/backend/application/raffle/RaffleValidationService.java
@@ -98,7 +98,7 @@ public class RaffleValidationService {
     }
 
     // 생성 시: 같은 raffleProductId가 이미 존재하면 예외
-    public void ensureUniqueRaffleProductId(String raffleProductId) {
+    public void ensureUniqueRaffleProductId(Long raffleProductId) {
         if (raffleProductId == null) return;
         if (raffleRepository.existsByRaffleProductId(raffleProductId)) {
             throw new IllegalStateException("해당 상품으로 등록된 추첨이 이미 존재합니다.");
@@ -106,7 +106,7 @@ public class RaffleValidationService {
     }
 
     // 수정 시: 동일한 raffleId인 경우는 허용, 다른 엔티티가 이미 사용 중이면 예외
-    public void ensureUniqueRaffleProductIdForUpdate(Long currentRaffleId, String raffleProductId) {
+    public void ensureUniqueRaffleProductIdForUpdate(Long currentRaffleId, Long raffleProductId) {
         if (raffleProductId == null) return;
         raffleRepository.findByRaffleProductId(raffleProductId)
                 .ifPresent(existing -> {

--- a/backend/src/main/java/groom/backend/application/raffle/RaffleValidationService.java
+++ b/backend/src/main/java/groom/backend/application/raffle/RaffleValidationService.java
@@ -5,8 +5,8 @@ import groom.backend.domain.auth.enums.Role;
 import groom.backend.domain.raffle.entity.Raffle;
 import groom.backend.domain.raffle.enums.RaffleStatus;
 import groom.backend.domain.raffle.repository.RaffleRepository;
+import groom.backend.domain.raffle.repository.RaffleTicketRepository;
 import groom.backend.interfaces.raffle.dto.request.RaffleRequest;
-import groom.backend.interfaces.raffle.persistence.repository.springData.SpringDataRaffleTicketRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -18,7 +18,7 @@ import java.util.Objects;
 public class RaffleValidationService {
 
     private final RaffleRepository raffleRepository;
-    private final SpringDataRaffleTicketRepository raffleTicketRepo;
+    private final RaffleTicketRepository raffleTicketRepo;
 
     // TODO : request 검증 로직 추가 필요
     // RaffleProductId, WinnerProductId 존재하는지 등
@@ -44,6 +44,23 @@ public class RaffleValidationService {
         }
         if (now.isAfter(raffle.getEntryEndAt())) {
             throw new IllegalStateException("응모 기간이 종료되었습니다.");
+        }
+    }
+
+    // 추첨 가능 여부 검증
+    public void validateRaffleForDraw(Raffle raffle) {
+        if (raffle == null) {
+            throw new IllegalStateException("해당 추첨이 존재하지 않습니다.");
+        }
+        // TODO : 추후 배치 추가 될 시 조건 엄격하게 CLOSED 만 허용하도록 변경 필요
+        if (!(raffle.getStatus() == RaffleStatus.CLOSED
+                || raffle.getStatus() == RaffleStatus.ACTIVE)) {
+            throw new IllegalStateException("현재 진행중인 추첨이 아닙니다.");
+        }
+
+        // TODO : 추후 배치 추가 될 시 당일 여부 검사로 변경 필요
+        if(LocalDateTime.now().isBefore(raffle.getRaffleDrawAt())) {
+            throw new IllegalStateException("아직 추첨일이 되지 않았습니다.");
         }
     }
 

--- a/backend/src/main/java/groom/backend/domain/raffle/entity/Raffle.java
+++ b/backend/src/main/java/groom/backend/domain/raffle/entity/Raffle.java
@@ -53,6 +53,11 @@ public class Raffle {
         if(request.getRaffleDrawAt() != null) {
             this.raffleDrawAt = request.getRaffleDrawAt();
         }
-        this.updatedAt = LocalDateTime.now();
+        //this.updatedAt = LocalDateTime.now();
+    }
+
+    public void updateStatus(RaffleStatus status) {
+        this.status = status;
+        //this.updatedAt = LocalDateTime.now();
     }
 }

--- a/backend/src/main/java/groom/backend/domain/raffle/entity/Raffle.java
+++ b/backend/src/main/java/groom/backend/domain/raffle/entity/Raffle.java
@@ -53,11 +53,9 @@ public class Raffle {
         if(request.getRaffleDrawAt() != null) {
             this.raffleDrawAt = request.getRaffleDrawAt();
         }
-        //this.updatedAt = LocalDateTime.now();
     }
 
     public void updateStatus(RaffleStatus status) {
         this.status = status;
-        //this.updatedAt = LocalDateTime.now();
     }
 }

--- a/backend/src/main/java/groom/backend/domain/raffle/entity/Raffle.java
+++ b/backend/src/main/java/groom/backend/domain/raffle/entity/Raffle.java
@@ -12,8 +12,8 @@ import java.time.LocalDateTime;
 public class Raffle {
 
     private Long raffleId;
-    private String raffleProductId;
-    private String winnerProductId;
+    private Long raffleProductId;
+    private Long winnerProductId;
     private String title;
     private String description;
     private int winnersCount;

--- a/backend/src/main/java/groom/backend/domain/raffle/entity/RaffleWinner.java
+++ b/backend/src/main/java/groom/backend/domain/raffle/entity/RaffleWinner.java
@@ -11,8 +11,9 @@ import java.time.LocalDateTime;
 public class RaffleWinner {
 
     private Long raffleWinnerId;
-    private RaffleWinnerStatus status;
     private Long raffleTicketId;
+    private RaffleWinnerStatus status;
+    private Integer rank;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 

--- a/backend/src/main/java/groom/backend/domain/raffle/repository/RaffleRepository.java
+++ b/backend/src/main/java/groom/backend/domain/raffle/repository/RaffleRepository.java
@@ -10,12 +10,12 @@ import java.util.Optional;
 public interface RaffleRepository {
     Optional<Raffle> findById(Long id);
     Raffle save(Raffle raffle);
-    boolean existsByRaffleProductId(String raffleProductId);
+    boolean existsByRaffleProductId(Long raffleProductId);
     void deleteById(Long id);
 
     // 도메인 수준의 검색 기준을 사용하도록 변경
     Page<Raffle> search(RaffleSearchCriteria cond, Pageable pageable);
 
     // 추첨용 상품으로 RaffleId 조회
-    Optional<Raffle> findByRaffleProductId(String raffleProductId);
+    Optional<Raffle> findByRaffleProductId(Long raffleProductId);
 }

--- a/backend/src/main/java/groom/backend/domain/raffle/repository/RaffleTicketRepository.java
+++ b/backend/src/main/java/groom/backend/domain/raffle/repository/RaffleTicketRepository.java
@@ -5,6 +5,10 @@ import groom.backend.domain.raffle.entity.RaffleTicket;
 public interface RaffleTicketRepository {
     RaffleTicket save(RaffleTicket raffle);
 
+    // 특정 래플에 대해 총 사용자 수 추출
+    int countDistinctUserByRaffleId(Long raffleId);
+
+    // 특정 래플과 사용자에 대한 티켓 수를 반환
     int countByRaffleIdAndUserId(Long raffleId, Long userId);
 
 }

--- a/backend/src/main/java/groom/backend/domain/raffle/repository/RaffleWinnerRepository.java
+++ b/backend/src/main/java/groom/backend/domain/raffle/repository/RaffleWinnerRepository.java
@@ -1,4 +1,16 @@
 package groom.backend.domain.raffle.repository;
 
+import groom.backend.domain.raffle.entity.RaffleWinner;
+import groom.backend.interfaces.raffle.dto.notification.RaffleWinnerNotification;
+import groom.backend.interfaces.raffle.dto.request.RaffleDrawCondition;
+
+import java.util.List;
+
 public interface RaffleWinnerRepository {
+    RaffleWinner save(RaffleWinner raffleWinner);
+
+    List<RaffleWinnerNotification> findNotificationsByRaffleId(Long raffleId);
+
+    int countWinnerByRaffleId(Long raffleId);
+    int pickWinnersNative (RaffleDrawCondition condition);
 }

--- a/backend/src/main/java/groom/backend/interfaces/raffle/RaffleController.java
+++ b/backend/src/main/java/groom/backend/interfaces/raffle/RaffleController.java
@@ -1,6 +1,7 @@
 package groom.backend.interfaces.raffle;
 
 import groom.backend.application.raffle.RaffleApplicationService;
+import groom.backend.application.raffle.RaffleDrawApplicationService;
 import groom.backend.application.raffle.RaffleTicketApplicationService;
 import groom.backend.domain.auth.entity.User;
 import groom.backend.domain.raffle.criteria.RaffleSearchCriteria;
@@ -25,6 +26,7 @@ public class RaffleController {
 
     private final RaffleApplicationService raffleApplicationService;
     private final RaffleTicketApplicationService raffleTicketApplicationService;
+    private final RaffleDrawApplicationService raffleDrawApplicationService;
 
     @PostMapping
     public ResponseEntity<RaffleResponse> createRaffle(@AuthenticationPrincipal(expression = "user") User user , @RequestBody RaffleRequest raffleRequest) {
@@ -97,5 +99,19 @@ public class RaffleController {
 
         raffleTicketApplicationService.addToEntryCart(raffleId, user, count);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @PostMapping("/{raffleId}/draws")
+    public ResponseEntity<Void> drawRaffleWinners(@AuthenticationPrincipal(expression = "user") User user,
+                                                  @PathVariable Long raffleId) {
+        if (user == null || user.getEmail() == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        // 추첨 실행
+        raffleDrawApplicationService.drawRaffleWinners(user, raffleId);
+        // TODO: 당첨자 알람 전송
+        raffleDrawApplicationService.sendRaffleWinnersNotification(raffleId);
+
+        return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/groom/backend/interfaces/raffle/dto/notification/RaffleWinnerNotification.java
+++ b/backend/src/main/java/groom/backend/interfaces/raffle/dto/notification/RaffleWinnerNotification.java
@@ -1,0 +1,13 @@
+package groom.backend.interfaces.raffle.dto.notification;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class RaffleWinnerNotification {
+    private Long raffleTicketId;
+    private Long userId;
+    private Long productId;
+    private String message;
+}

--- a/backend/src/main/java/groom/backend/interfaces/raffle/dto/request/RaffleDrawCondition.java
+++ b/backend/src/main/java/groom/backend/interfaces/raffle/dto/request/RaffleDrawCondition.java
@@ -1,0 +1,13 @@
+package groom.backend.interfaces.raffle.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class RaffleDrawCondition {
+    private Long raffleId;
+    private Integer numberOfWinners;
+}

--- a/backend/src/main/java/groom/backend/interfaces/raffle/dto/request/RaffleRequest.java
+++ b/backend/src/main/java/groom/backend/interfaces/raffle/dto/request/RaffleRequest.java
@@ -14,9 +14,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 public class RaffleRequest {
-    @NotBlank
     private Long raffleProductId;
-    @NotBlank
     private Long winnerProductId;
     @NotBlank
     private String title;

--- a/backend/src/main/java/groom/backend/interfaces/raffle/dto/request/RaffleRequest.java
+++ b/backend/src/main/java/groom/backend/interfaces/raffle/dto/request/RaffleRequest.java
@@ -15,9 +15,9 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class RaffleRequest {
     @NotBlank
-    private String raffleProductId;
+    private Long raffleProductId;
     @NotBlank
-    private String winnerProductId;
+    private Long winnerProductId;
     @NotBlank
     private String title;
     private String description;

--- a/backend/src/main/java/groom/backend/interfaces/raffle/dto/response/RaffleResponse.java
+++ b/backend/src/main/java/groom/backend/interfaces/raffle/dto/response/RaffleResponse.java
@@ -13,8 +13,8 @@ import java.time.LocalDateTime;
 @Builder
 public class RaffleResponse {
     private Long raffleId;
-    private String raffleProductId;
-    private String winnerProductId;
+    private Long raffleProductId;
+    private Long winnerProductId;
     private String title;
     private String description;
     private int winnersCount;

--- a/backend/src/main/java/groom/backend/interfaces/raffle/persistence/Entity/RaffleJpaEntity.java
+++ b/backend/src/main/java/groom/backend/interfaces/raffle/persistence/Entity/RaffleJpaEntity.java
@@ -1,11 +1,14 @@
 package groom.backend.interfaces.raffle.persistence.Entity;
 
+import groom.backend.domain.raffle.entity.Raffle;
 import groom.backend.domain.raffle.enums.RaffleStatus;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "raffles")
@@ -37,6 +40,9 @@ public class RaffleJpaEntity {
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
+    @OneToMany(mappedBy = "raffle", fetch = FetchType.LAZY)
+    private List<RaffleTicketJpaEntity> tickets = new ArrayList<>();
+
     @PreUpdate
     protected void onUpdate() {
         updatedAt = LocalDateTime.now();
@@ -46,6 +52,27 @@ public class RaffleJpaEntity {
     protected void onCreate() {
         createdAt = LocalDateTime.now();
         updatedAt = LocalDateTime.now();
+    }
+
+    public static RaffleJpaEntity from(Raffle raffle) {
+
+        RaffleJpaEntity.RaffleJpaEntityBuilder builder = RaffleJpaEntity.builder()
+                .raffleProductId(raffle.getRaffleProductId())
+                .winnerProductId(raffle.getWinnerProductId())
+                .title(raffle.getTitle())
+                .description(raffle.getDescription())
+                .winnersCount(raffle.getWinnersCount())
+                .maxEntriesPerUser(raffle.getMaxEntriesPerUser())
+                .entryStartAt(raffle.getEntryStartAt())
+                .entryEndAt(raffle.getEntryEndAt())
+                .raffleDrawAt(raffle.getRaffleDrawAt())
+                .status(raffle.getStatus());
+
+        if (raffle.getRaffleId() != null){
+            builder.raffleId(raffle.getRaffleId());
+        }
+
+        return builder.build();
     }
 
 

--- a/backend/src/main/java/groom/backend/interfaces/raffle/persistence/Entity/RaffleJpaEntity.java
+++ b/backend/src/main/java/groom/backend/interfaces/raffle/persistence/Entity/RaffleJpaEntity.java
@@ -19,9 +19,9 @@ public class RaffleJpaEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long raffleId;
     @NotBlank
-    private String raffleProductId;
+    private Long raffleProductId;
     @NotBlank
-    private String winnerProductId;
+    private Long winnerProductId;
     @NotBlank
     private String title;
     private String description;

--- a/backend/src/main/java/groom/backend/interfaces/raffle/persistence/Entity/RaffleJpaEntity.java
+++ b/backend/src/main/java/groom/backend/interfaces/raffle/persistence/Entity/RaffleJpaEntity.java
@@ -7,8 +7,6 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Table(name = "raffles")
@@ -21,9 +19,7 @@ public class RaffleJpaEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long raffleId;
-    @NotBlank
     private Long raffleProductId;
-    @NotBlank
     private Long winnerProductId;
     @NotBlank
     private String title;
@@ -39,9 +35,6 @@ public class RaffleJpaEntity {
     private LocalDateTime createdAt;
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
-
-    @OneToMany(mappedBy = "raffle", fetch = FetchType.LAZY)
-    private List<RaffleTicketJpaEntity> tickets = new ArrayList<>();
 
     @PreUpdate
     protected void onUpdate() {

--- a/backend/src/main/java/groom/backend/interfaces/raffle/persistence/Entity/RaffleTicketJpaEntity.java
+++ b/backend/src/main/java/groom/backend/interfaces/raffle/persistence/Entity/RaffleTicketJpaEntity.java
@@ -4,8 +4,6 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Table(name = "raffle_tickets",
@@ -27,8 +25,5 @@ public class RaffleTicketJpaEntity {
     @ManyToOne
     @JoinColumn(name = "raffle_id")
     private RaffleJpaEntity raffle;
-
-    @OneToMany(mappedBy = "raffleTicket", fetch = FetchType.LAZY)
-    private List<RaffleWinnerJpaEntity> winners = new ArrayList<>();
 
 }

--- a/backend/src/main/java/groom/backend/interfaces/raffle/persistence/Entity/RaffleTicketJpaEntity.java
+++ b/backend/src/main/java/groom/backend/interfaces/raffle/persistence/Entity/RaffleTicketJpaEntity.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "raffle_tickets",
@@ -19,8 +21,14 @@ public class RaffleTicketJpaEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long raffleTicketId;
     private Long ticketNumber;
-    private Long raffleId;
     private Long userId;
     private LocalDateTime createdAt;
+
+    @ManyToOne
+    @JoinColumn(name = "raffle_id")
+    private RaffleJpaEntity raffle;
+
+    @OneToMany(mappedBy = "raffleTicket", fetch = FetchType.LAZY)
+    private List<RaffleWinnerJpaEntity> winners = new ArrayList<>();
 
 }

--- a/backend/src/main/java/groom/backend/interfaces/raffle/persistence/Entity/RaffleWinnerJpaEntity.java
+++ b/backend/src/main/java/groom/backend/interfaces/raffle/persistence/Entity/RaffleWinnerJpaEntity.java
@@ -20,7 +20,11 @@ public class RaffleWinnerJpaEntity {
     private Long raffleWinnerId;
     @Enumerated(EnumType.STRING)
     private RaffleWinnerStatus status;
-    private Long raffleTicketId;
+    private Integer rank;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+
+    @ManyToOne
+    @JoinColumn(name = "raffle_ticket_id")
+    private RaffleTicketJpaEntity raffleTicket;
 }

--- a/backend/src/main/java/groom/backend/interfaces/raffle/persistence/repository/jpa/JpaRaffleRepository.java
+++ b/backend/src/main/java/groom/backend/interfaces/raffle/persistence/repository/jpa/JpaRaffleRepository.java
@@ -38,7 +38,7 @@ public class JpaRaffleRepository implements RaffleRepository {
     }
 
     @Override
-    public boolean existsByRaffleProductId(String raffleProductId) {
+    public boolean existsByRaffleProductId(Long raffleProductId) {
         return raffleRepository.existsByRaffleProductId(raffleProductId);
     }
 
@@ -95,7 +95,7 @@ public class JpaRaffleRepository implements RaffleRepository {
 
     // 추첨용 상품 Id 로 추첨 정보 받아오기
     @Override
-    public Optional<Raffle> findByRaffleProductId(String raffleProductId) {
+    public Optional<Raffle> findByRaffleProductId(Long raffleProductId) {
         return raffleRepository.findByRaffleProductId(raffleProductId);
     }
 

--- a/backend/src/main/java/groom/backend/interfaces/raffle/persistence/repository/jpa/JpaRaffleTicketRepository.java
+++ b/backend/src/main/java/groom/backend/interfaces/raffle/persistence/repository/jpa/JpaRaffleTicketRepository.java
@@ -21,6 +21,12 @@ public class JpaRaffleTicketRepository implements RaffleTicketRepository {
         return toDomain(saved);
     }
 
+
+    @Override
+    public int countDistinctUserByRaffleId(Long raffleId) {
+        return ticketRepository.countDistinctUserByRaffleId(raffleId);
+    }
+
     @Override
     public int countByRaffleIdAndUserId(Long raffleId, Long userId) {
         return ticketRepository.countByRaffle_RaffleIdAndUserId(raffleId, userId);

--- a/backend/src/main/java/groom/backend/interfaces/raffle/persistence/repository/jpa/JpaRaffleTicketRepository.java
+++ b/backend/src/main/java/groom/backend/interfaces/raffle/persistence/repository/jpa/JpaRaffleTicketRepository.java
@@ -2,6 +2,7 @@ package groom.backend.interfaces.raffle.persistence.repository.jpa;
 
 import groom.backend.domain.raffle.entity.RaffleTicket;
 import groom.backend.domain.raffle.repository.RaffleTicketRepository;
+import groom.backend.interfaces.raffle.persistence.Entity.RaffleJpaEntity;
 import groom.backend.interfaces.raffle.persistence.Entity.RaffleTicketJpaEntity;
 import groom.backend.interfaces.raffle.persistence.repository.springData.SpringDataRaffleTicketRepository;
 import org.springframework.stereotype.Repository;
@@ -22,21 +23,24 @@ public class JpaRaffleTicketRepository implements RaffleTicketRepository {
 
     @Override
     public int countByRaffleIdAndUserId(Long raffleId, Long userId) {
-        return ticketRepository.countByRaffleIdAndUserId(raffleId, userId);
+        return ticketRepository.countByRaffle_RaffleIdAndUserId(raffleId, userId);
     }
 
     private RaffleTicket toDomain(RaffleTicketJpaEntity e) {
         return new RaffleTicket(e.getRaffleTicketId(),
                 e.getTicketNumber(),
-                e.getRaffleId(),
+                e.getRaffle().getRaffleId(),
                 e.getUserId(),
                 e.getCreatedAt()
         );
     }
 
     private RaffleTicketJpaEntity toEntity(RaffleTicket raffle) {
+        RaffleJpaEntity ref = new RaffleJpaEntity();
+        ref.setRaffleId(raffle.getRaffleId());
+
         return RaffleTicketJpaEntity.builder()
-                .raffleId(raffle.getRaffleId())
+                .raffle(ref)
                 .raffleTicketId(raffle.getRaffleTicketId())
                 .ticketNumber(raffle.getTicketNumber())
                 .userId(raffle.getUserId())

--- a/backend/src/main/java/groom/backend/interfaces/raffle/persistence/repository/jpa/JpaRaffleWinnerRepository.java
+++ b/backend/src/main/java/groom/backend/interfaces/raffle/persistence/repository/jpa/JpaRaffleWinnerRepository.java
@@ -1,8 +1,68 @@
 package groom.backend.interfaces.raffle.persistence.repository.jpa;
 
+import groom.backend.domain.raffle.entity.RaffleWinner;
+import groom.backend.interfaces.raffle.dto.notification.RaffleWinnerNotification;
 import groom.backend.domain.raffle.repository.RaffleWinnerRepository;
+import groom.backend.interfaces.raffle.dto.request.RaffleDrawCondition;
+import groom.backend.interfaces.raffle.persistence.Entity.RaffleTicketJpaEntity;
+import groom.backend.interfaces.raffle.persistence.Entity.RaffleWinnerJpaEntity;
+import groom.backend.interfaces.raffle.persistence.repository.springData.SpringDataRaffleWinnerRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public class JpaRaffleWinnerRepository implements RaffleWinnerRepository {
+
+    private final SpringDataRaffleWinnerRepository winnerRepository;
+
+    public JpaRaffleWinnerRepository(SpringDataRaffleWinnerRepository winnerRepository) {
+        this.winnerRepository = winnerRepository;
+    }
+
+    @Override
+    public int pickWinnersNative(RaffleDrawCondition condition) {
+        return winnerRepository.pickWinnersNative(condition);
+    }
+
+    @Override
+    public List<RaffleWinnerNotification> findNotificationsByRaffleId(Long raffleId) {
+        return winnerRepository.findNotificationsByRaffleId(raffleId);
+    }
+
+    @Override
+    public int countWinnerByRaffleId(Long raffleId) {
+        return winnerRepository.countByRaffleTicket_Raffle_RaffleId(raffleId);
+    }
+
+    @Override
+    public RaffleWinner save(RaffleWinner raffleWinner) {
+        RaffleWinnerJpaEntity saved = winnerRepository.save(toEntity(raffleWinner));
+        return toDomain(saved);
+    }
+
+    private RaffleWinner toDomain(RaffleWinnerJpaEntity e) {
+        return new RaffleWinner(
+                e.getRaffleWinnerId(),
+                e.getRaffleTicket().getRaffleTicketId(),
+                e.getStatus(),
+                e.getRank(),
+                e.getCreatedAt(),
+                e.getUpdatedAt()
+        );
+    }
+
+    private RaffleWinnerJpaEntity toEntity(RaffleWinner raffleWinner) {
+        RaffleTicketJpaEntity ref = new RaffleTicketJpaEntity();
+        ref.setRaffleTicketId(raffleWinner.getRaffleTicketId());
+
+        return RaffleWinnerJpaEntity.builder()
+                .raffleWinnerId(raffleWinner.getRaffleWinnerId())
+                .raffleTicket(ref)
+                .status(raffleWinner.getStatus())
+                .rank(raffleWinner.getRank())
+                .createdAt(raffleWinner.getCreatedAt())
+                .updatedAt(raffleWinner.getUpdatedAt())
+                .build();
+    }
 }

--- a/backend/src/main/java/groom/backend/interfaces/raffle/persistence/repository/springData/SpringDataRaffleRepository.java
+++ b/backend/src/main/java/groom/backend/interfaces/raffle/persistence/repository/springData/SpringDataRaffleRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import java.util.Optional;
 
 public interface SpringDataRaffleRepository extends JpaRepository<RaffleJpaEntity, Long>, JpaSpecificationExecutor<RaffleJpaEntity> {
-    boolean existsByRaffleProductId(String raffleProductId);
+    boolean existsByRaffleProductId(Long raffleProductId);
 
-    Optional<Raffle> findByRaffleProductId(String raffleProductId);
+    Optional<Raffle> findByRaffleProductId(Long raffleProductId);
 }

--- a/backend/src/main/java/groom/backend/interfaces/raffle/persistence/repository/springData/SpringDataRaffleTicketRepository.java
+++ b/backend/src/main/java/groom/backend/interfaces/raffle/persistence/repository/springData/SpringDataRaffleTicketRepository.java
@@ -2,7 +2,11 @@ package groom.backend.interfaces.raffle.persistence.repository.springData;
 
 import groom.backend.interfaces.raffle.persistence.Entity.RaffleTicketJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface SpringDataRaffleTicketRepository extends JpaRepository<RaffleTicketJpaEntity, Long> {
-    int countByRaffleIdAndUserId(Long raffleId, Long userId);
+    int countByRaffle_RaffleIdAndUserId(Long raffleId, Long userId);
+    @Query("select count(distinct rt.userId) from RaffleTicketJpaEntity rt where rt.raffle.raffleId = :raffleId")
+    int countDistinctUserByRaffleId(Long raffleId);
+
 }

--- a/backend/src/main/java/groom/backend/interfaces/raffle/persistence/repository/springData/SpringDataRaffleWinnerRepository.java
+++ b/backend/src/main/java/groom/backend/interfaces/raffle/persistence/repository/springData/SpringDataRaffleWinnerRepository.java
@@ -31,7 +31,6 @@ public interface SpringDataRaffleWinnerRepository extends JpaRepository<RaffleWi
             nativeQuery = true)
     int pickWinnersNative(@Param("cond") RaffleDrawCondition cond);
 
-    @Modifying
     @Query(value = ""
             + "SELECT w.raffle_ticket_id, t.user_id, r.winner_product_id as product_id, concat('축하합니다. ', p.name,'에 당첨 되셨습니다.' ) as message "
             + "FROM raffles r "

--- a/backend/src/main/java/groom/backend/interfaces/raffle/persistence/repository/springData/SpringDataRaffleWinnerRepository.java
+++ b/backend/src/main/java/groom/backend/interfaces/raffle/persistence/repository/springData/SpringDataRaffleWinnerRepository.java
@@ -1,8 +1,47 @@
 package groom.backend.interfaces.raffle.persistence.repository.springData;
 
+import groom.backend.interfaces.raffle.dto.notification.RaffleWinnerNotification;
+import groom.backend.interfaces.raffle.dto.request.RaffleDrawCondition;
 import groom.backend.interfaces.raffle.persistence.Entity.RaffleWinnerJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 
 public interface SpringDataRaffleWinnerRepository extends JpaRepository<RaffleWinnerJpaEntity, Long> {
+    @Modifying
+    @Query(value = ""
+            + "WITH tickets_random AS ( "
+            + "  SELECT raffle_ticket_id AS ticket_id, user_id, random() AS rnd "
+            + "  FROM raffle_tickets "
+            + "  WHERE raffle_id = :#{#cond.raffleId} "
+            + "), best_per_user AS ( "  // 각 사용자별로 가장 유리한(최소) rnd 값을 가진 티켓만 남김 -> 티켓 수가 많을수록 최소값이 더 유리할 확률이 높아짐
+            + "  SELECT DISTINCT ON (user_id) ticket_id, user_id, rnd "
+            + "  FROM tickets_random "
+            + "  ORDER BY user_id, rnd "
+            + "), picked AS ( " // 사용자별 최소 rnd들 중에서 상위 N명(가장 작은 rnd)을 선택
+            + "  SELECT ticket_id, user_id, rnd FROM best_per_user ORDER BY rnd LIMIT :#{#cond.numberOfWinners} "
+            + ") "
+            + "INSERT INTO raffle_winners (raffle_ticket_id, rank, status, created_at, updated_at) "
+            + "SELECT ticket_id, row_number() OVER (ORDER BY rnd), 'RESERVED' ,NOW(), NOW()"
+            + "FROM picked",
+            nativeQuery = true)
+    int pickWinnersNative(@Param("cond") RaffleDrawCondition cond);
+
+    @Modifying
+    @Query(value = ""
+            + "SELECT w.raffle_ticket_id, t.user_id, r.winner_product_id as product_id, concat('축하합니다. ', p.name,'에 당첨 되셨습니다.' ) as message "
+            + "FROM raffles r "
+            + "JOIN raffle_tickets t ON r.raffle_id = t.raffle_id "
+            + "JOIN raffle_winners w ON t.raffle_ticket_id = w.raffle_ticket_id "
+            + "JOIN product p ON r.winner_product_id = p.id "
+            + "WHERE r.raffle_id = :raffleId ",
+            nativeQuery = true)
+    List<RaffleWinnerNotification> findNotificationsByRaffleId(Long raffleId);
+
+    // raffle_winners 테이블의 행(선정된 당첨자) 총수
+    int countByRaffleTicket_Raffle_RaffleId(Long raffleId);
 }

--- a/backend/src/test/java/groom/backend/application/raffle/RaffleTicketApplicationServiceCreateTicketTest.java
+++ b/backend/src/test/java/groom/backend/application/raffle/RaffleTicketApplicationServiceCreateTicketTest.java
@@ -45,7 +45,7 @@ public class RaffleTicketApplicationServiceCreateTicketTest {
         given(raffle.getRaffleId()).willReturn(1L);
         given(user.getId()).willReturn(1L);
 
-        Raffle findRaffle = raffleApplicationService.findByRaffleProductId("4");
+        Raffle findRaffle = raffleApplicationService.findByRaffleProductId(4L);
 
         raffleValidationService.validateRaffleForEntry(findRaffle);
 

--- a/backend/src/test/java/groom/backend/application/raffle/RaffleTicketApplicationServiceCreateTicketTest.java
+++ b/backend/src/test/java/groom/backend/application/raffle/RaffleTicketApplicationServiceCreateTicketTest.java
@@ -79,7 +79,7 @@ public class RaffleTicketApplicationServiceCreateTicketTest {
 
         // then
         assertNotNull(result);
-        assertEquals(10L, result.getRaffleId());
+        assertEquals(10L, result.getRaffle().getRaffleId());
         assertEquals(100L, result.getUserId());
         assertEquals(5L, result.getTicketNumber());
         assertNotNull(result.getCreatedAt());
@@ -89,7 +89,7 @@ public class RaffleTicketApplicationServiceCreateTicketTest {
         then(raffleTicketRepo).should().save(captor.capture());
         RaffleTicketJpaEntity saved = captor.getValue();
         assertEquals(5L, saved.getTicketNumber());
-        assertEquals(10L, saved.getRaffleId());
+        assertEquals(10L, saved.getRaffle().getRaffleId());
         assertEquals(100L, saved.getUserId());
 
         then(allocationService).should().allocateNextTicketNumber(10L);


### PR DESCRIPTION
## 📌 개요
- 추첨 응모 기간 종료 후 추첨 기간때 추첨 실행

## 🚀 관련 이슈
- #41 

## ✅ 변경 사항
- 추첨 실행 구현
- 당첨자 메세지 전송 데이터 추출
- ProductId 타입 변경 varchar -> bigint


## 📝 상세 내용
- endPoint : POST raffles/{raffleId}/draws
- 실행 -> 어드민 권한 확인 -> 마스터 엔티티 존재확인 -> 상태확인(CLOSED, ACTIVE) -> 추첨일이 현재보디 이전인지  
          -> 응모자 수 확인(0명이면 예외) -> 기존 당첨자 수 확인 -> 추첨 실행 ->  참가자수보다 당첨자 미달검증, 당첨자가 설정한 당첨자 수보다 많으면 예외 -> 설정된 당첨자보다 당첨자가 적으면 로그남김 -> 상품 수량 차감(미개발) -> 추첨 마스터 상태 업데이트  -> 알람 전송테이블 등록


## 📚 관련 문서
-
