### PR TITLE
fix : 인증 예외 발생 시 ErrorResponse 와 동일한 응답으로 수정

### DIFF
--- a/backend/src/main/java/groom/backend/infrastructure/config/SecurityConfig.java
+++ b/backend/src/main/java/groom/backend/infrastructure/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import groom.backend.infrastructure.security.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
@@ -31,6 +32,7 @@ public class SecurityConfig {
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))   // 세션 비활성화
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/v1/auth/signup", "/v1/auth/login", "/v1/auth/refresh").permitAll()
+                        .requestMatchers(HttpMethod.GET,"/v1/raffles", "/v1/product").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()  // Swagger 경로 허용
                         .anyRequest().authenticated()  // 모든 요청 인증 필요
                 )

--- a/backend/src/main/java/groom/backend/infrastructure/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/groom/backend/infrastructure/security/JwtAuthenticationFilter.java
@@ -1,5 +1,11 @@
 package groom.backend.infrastructure.security;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import groom.backend.common.exception.dto.ErrorResponse;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -11,10 +17,12 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.List;
 
 @Slf4j
 @Component
@@ -22,6 +30,45 @@ import java.io.IOException;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
+
+    private static final ObjectMapper LOCAL_OBJECT_MAPPER = createLocalObjectMapper();
+
+
+    private static ObjectMapper createLocalObjectMapper() {
+        ObjectMapper om = new ObjectMapper();
+        om.registerModule(new JavaTimeModule());
+        om.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        return om;
+    }
+
+    private static final List<String> EXCLUDE_PATTERNS = List.of(
+            "/api/v1/auth/signup",
+            "/api/v1/auth/login",
+            "/api/v1/auth/refresh",
+            "/api/swagger-ui/**",
+            "/api/v3/api-docs/**",
+            "/api/swagger-ui.html"
+    );
+
+    private final AntPathMatcher pathMatcher = new AntPathMatcher();
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        String path = request.getRequestURI();
+
+        if ("GET".equalsIgnoreCase(request.getMethod()) &&
+                ("/api/v1/product".equals(path) || "/api/v1/raffles".equals(path))) {
+            return true;
+        }
+
+        for (String pattern : EXCLUDE_PATTERNS) {
+            if (pathMatcher.match(pattern, path)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     private String resolveToken(HttpServletRequest request) {
         String bearerToken = request.getHeader("Authorization");
@@ -36,18 +83,50 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         try {
             String token = resolveToken(request);
 
-            if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
-                Authentication authentication = jwtTokenProvider.getAuthentication(token);
+            if(StringUtils.hasText(token)) {
+                if(jwtTokenProvider.validateToken(token)) {
+                    Authentication authentication = jwtTokenProvider.getAuthentication(token);
 
-                ((AbstractAuthenticationToken) authentication)
-                        .setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-                SecurityContextHolder.getContext().setAuthentication(authentication);
-
+                    ((AbstractAuthenticationToken) authentication)
+                            .setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                }
+            } else {
+                // 토큰이 없거나 유효하지 않은 경우
+                setErrorResponse(response, HttpServletResponse.SC_UNAUTHORIZED, "INVALID_TOKEN", "인증 정보가 유효하지 않습니다. 다시 로그인해 주세요.");
+                return;
             }
+
+        } catch (ExpiredJwtException e) {
+            // 만료된 토큰
+            setErrorResponse(response, HttpServletResponse.SC_UNAUTHORIZED, "EXPIRED_TOKEN", "세션이 만료되었습니다. 다시 로그인해 주세요.");
+            return;
+        } catch (JwtException | IllegalArgumentException e) {
+            // JWT 관련 예외는 AuthenticationEntryPoint로 위임하여 401 처리
+            setErrorResponse(response, HttpServletResponse.SC_UNAUTHORIZED, "INVALID_TOKEN", e.getMessage());
+            return;
         } catch (Exception e) {
-            log.error("인증 설정 중 오류 발생", e);
+            // 기타 예외도 엔트리포인트로 처리하거나 별도로 로깅/응답 처리
+            setErrorResponse(response, HttpServletResponse.SC_UNAUTHORIZED, "UNAUTHORIZED", "인증 처리 중 오류가 발생했습니다.");
+            return;
         }
 
         filterChain.doFilter(request, response);
+    }
+
+    private void setErrorResponse(HttpServletResponse response, int status, String code, String message) throws IOException {
+        // 이전에 쓰여진 내용이 있을 수 있으니 초기화
+        response.resetBuffer();
+        response.setStatus(status);
+        response.setCharacterEncoding(java.nio.charset.StandardCharsets.UTF_8.name());
+        response.setContentType("application/json;charset=UTF-8");
+
+
+        ErrorResponse errorResponse = ErrorResponse.of(status, code, message);
+        byte[] bytes = LOCAL_OBJECT_MAPPER.writeValueAsBytes(errorResponse);
+
+        response.getOutputStream().write(bytes);
+        response.getOutputStream().flush();
+        response.flushBuffer();
     }
 }

--- a/backend/src/main/java/groom/backend/infrastructure/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/groom/backend/infrastructure/security/JwtAuthenticationFilter.java
@@ -83,8 +83,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         try {
             String token = resolveToken(request);
 
-            if(StringUtils.hasText(token)) {
-                if(jwtTokenProvider.validateToken(token)) {
+            if (StringUtils.hasText(token)) {
+                if (jwtTokenProvider.validateToken(token)) {
                     Authentication authentication = jwtTokenProvider.getAuthentication(token);
 
                     ((AbstractAuthenticationToken) authentication)
@@ -102,11 +102,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             setErrorResponse(response, HttpServletResponse.SC_UNAUTHORIZED, "EXPIRED_TOKEN", "세션이 만료되었습니다. 다시 로그인해 주세요.");
             return;
         } catch (JwtException | IllegalArgumentException e) {
-            // JWT 관련 예외는 AuthenticationEntryPoint로 위임하여 401 처리
+            // JWT 관련 예외는 이 필터에서 직접 401 응답으로 처리함
             setErrorResponse(response, HttpServletResponse.SC_UNAUTHORIZED, "INVALID_TOKEN", e.getMessage());
             return;
         } catch (Exception e) {
-            // 기타 예외도 엔트리포인트로 처리하거나 별도로 로깅/응답 처리
+            // 기타 예외는 이 필터에서 직접 401 응답을 반환하여 처리합니다.
             setErrorResponse(response, HttpServletResponse.SC_UNAUTHORIZED, "UNAUTHORIZED", "인증 처리 중 오류가 발생했습니다.");
             return;
         }
@@ -120,7 +120,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         response.setStatus(status);
         response.setCharacterEncoding(java.nio.charset.StandardCharsets.UTF_8.name());
         response.setContentType("application/json;charset=UTF-8");
-
 
         ErrorResponse errorResponse = ErrorResponse.of(status, code, message);
         byte[] bytes = LOCAL_OBJECT_MAPPER.writeValueAsBytes(errorResponse);

--- a/backend/src/main/java/groom/backend/infrastructure/security/JwtTokenProvider.java
+++ b/backend/src/main/java/groom/backend/infrastructure/security/JwtTokenProvider.java
@@ -77,16 +77,20 @@ public class JwtTokenProvider {
             return true;
         } catch (ExpiredJwtException e) {
             log.warn("만료된 JWT 토큰입니다.");
+            throw new ExpiredJwtException(e.getHeader(), e.getClaims(), "만료된 토큰입니다.");
         } catch (UnsupportedJwtException e) {
             log.warn("지원되지 않는 JWT 토큰입니다.");
+            throw new JwtException("인증 정보가 유효하지 않습니다. 다시 로그인해 주세요.");
         } catch (MalformedJwtException e) {
             log.warn("잘못된 JWT 토큰입니다.");
+            throw new JwtException("인증 정보가 유효하지 않습니다. 다시 로그인해 주세요.");
         } catch (SignatureException e) {
             log.warn("JWT 서명이 일치하지 않습니다.");
+            throw new JwtException("인증 정보가 유효하지 않습니다. 다시 로그인해 주세요.");
         } catch (IllegalArgumentException e) {
             log.warn("JWT 토큰이 비어있습니다.");
+            throw new JwtException("인증 정보가 유효하지 않습니다. 다시 로그인해 주세요.");
         }
-        return false;
     }
 
     private Claims getClaims(String token) {

--- a/backend/src/main/java/groom/backend/infrastructure/security/JwtTokenProvider.java
+++ b/backend/src/main/java/groom/backend/infrastructure/security/JwtTokenProvider.java
@@ -76,19 +76,19 @@ public class JwtTokenProvider {
             getClaims(token);
             return true;
         } catch (ExpiredJwtException e) {
-            log.warn("만료된 JWT 토큰입니다.");
+            log.debug("만료된 JWT 토큰입니다.");
             throw new ExpiredJwtException(e.getHeader(), e.getClaims(), "만료된 토큰입니다.");
         } catch (UnsupportedJwtException e) {
-            log.warn("지원되지 않는 JWT 토큰입니다.");
+            log.debug("지원되지 않는 JWT 토큰입니다.");
             throw new JwtException("인증 정보가 유효하지 않습니다. 다시 로그인해 주세요.");
         } catch (MalformedJwtException e) {
-            log.warn("잘못된 JWT 토큰입니다.");
+            log.debug("잘못된 JWT 토큰입니다.");
             throw new JwtException("인증 정보가 유효하지 않습니다. 다시 로그인해 주세요.");
         } catch (SignatureException e) {
-            log.warn("JWT 서명이 일치하지 않습니다.");
+            log.debug("JWT 서명이 일치하지 않습니다.");
             throw new JwtException("인증 정보가 유효하지 않습니다. 다시 로그인해 주세요.");
         } catch (IllegalArgumentException e) {
-            log.warn("JWT 토큰이 비어있습니다.");
+            log.debug("JWT 토큰이 비어있습니다.");
             throw new JwtException("인증 정보가 유효하지 않습니다. 다시 로그인해 주세요.");
         }
     }


### PR DESCRIPTION
## 📌 개요
- 예외 처리 시 ErrorResponse 처럼 동일한 응답형식 처리

## 🚀 관련 이슈
- close #102 

## ✅ 변경 사항
- SpringSecurity Config 에 추첨 목록, 상품 목록  권한없어도 접근 가능하게 처리
- Filter 수정
 - 1. config에 권한 없이 접근 가능한 영역들은 filter도 동작하지 않게 설정
 - 2. 예외를 잡아서 response만들어 return
- provider 에 검증 시 예외 발생 처리
- 

## 📝 상세 내용
-
-

## 📚 관련 문서
-
