### PR TITLE
feat : AOP + 커스텀 어노테이션으로  관리자, 사용자 권한을 분리

### DIFF
--- a/backend/src/main/java/groom/backend/common/annotation/CheckPermission.java
+++ b/backend/src/main/java/groom/backend/common/annotation/CheckPermission.java
@@ -1,0 +1,35 @@
+package groom.backend.common.annotation;
+
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 메서드 실행 전 권한을 확인하는 어노테이션.
+ *
+ * - 이 어노테이션이 적용된 메서드는 권한 검증 로직이 실행됨.
+ * - 주로 관리자 권한이 필요한 API에 사용됨.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CheckPermission {
+
+    // 검사할 권한 목록 (여러 개 가능)
+    String[] roles() default {"USER"};
+
+    // 검사 모드 : ALL - hasAuthority, ANY - hasAnyAuthority
+    Mode mode() default Mode.ANY;
+
+    Page page() default Page.BO;
+
+    enum Mode {
+        ALL, // hasAuthority : 모든 권한 필요
+        ANY // hasAnyAuthority : 하나 이상의 권한 필요
+    }
+
+    enum Page {
+        BO, FO
+    }
+}

--- a/backend/src/main/java/groom/backend/common/aop/PermissionAspect.java
+++ b/backend/src/main/java/groom/backend/common/aop/PermissionAspect.java
@@ -1,0 +1,82 @@
+package groom.backend.common.aop;
+
+import groom.backend.common.annotation.CheckPermission;
+import groom.backend.common.exception.BusinessException;
+import groom.backend.common.exception.ErrorCode;
+import groom.backend.infrastructure.security.JwtTokenProvider;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Aspect
+@Component
+@Slf4j
+public class PermissionAspect {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public PermissionAspect(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Before("@annotation(groom.backend.common.annotation.CheckPermission)")
+    public void checkPermission(JoinPoint joinPoint) {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated()) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED);
+        }
+
+        // 어노테이션에서 권한 정보 가져오기
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        CheckPermission permission = method.getAnnotation(CheckPermission.class);
+
+        String[] requiredRoles = permission.roles();
+        CheckPermission.Mode mode = permission.mode();
+        CheckPermission.Page page = permission.page();
+
+        Set<String> userRoleNames = auth.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.toSet());
+
+        // 요구 권한을 "ROLE_" 접두사로 정규화
+        Set<String> requiredNormalized = Arrays.stream(requiredRoles)
+                .map(r -> r.startsWith("ROLE_") ? r : "ROLE_" + r)
+                .collect(Collectors.toSet());
+
+        boolean hasPermission;
+        if (mode == CheckPermission.Mode.ALL) {
+            // 모든 권한이 있어야 함
+            hasPermission = userRoleNames.containsAll(requiredNormalized);
+        } else {
+            // 하나라도 일치하면 허용
+            hasPermission = requiredNormalized.stream().anyMatch(userRoleNames::contains);
+        }
+
+        if (!hasPermission) {
+
+            String message = "접근 권한이 없습니다.";
+
+            log.debug("필요한 권한: {}, 현재 권한: {}", requiredNormalized, userRoleNames);
+            if (page == CheckPermission.Page.BO) {
+                message = "필요한 권한: " + requiredNormalized + ", 현재 권한: " + userRoleNames;
+            }
+
+            throw new BusinessException(
+                    ErrorCode.ACCESS_DENIED,
+                    message
+            );
+        }
+    }
+}

--- a/backend/src/main/java/groom/backend/infrastructure/config/SecurityConfig.java
+++ b/backend/src/main/java/groom/backend/infrastructure/config/SecurityConfig.java
@@ -32,7 +32,6 @@ public class SecurityConfig {
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))   // 세션 비활성화
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/v1/auth/signup", "/v1/auth/login", "/v1/auth/refresh").permitAll()
-                        .requestMatchers(HttpMethod.GET,"/v1/raffles", "/v1/product").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()  // Swagger 경로 허용
                         .requestMatchers(HttpMethod.GET, "/v1/product/**").permitAll()  // 상품 조회 허용
                         .requestMatchers(HttpMethod.GET, "/v1/raffles/**").permitAll()  // 래플 조회 허용

--- a/backend/src/main/java/groom/backend/infrastructure/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/groom/backend/infrastructure/security/JwtAuthenticationFilter.java
@@ -33,7 +33,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private static final ObjectMapper LOCAL_OBJECT_MAPPER = createLocalObjectMapper();
 
-
     private static ObjectMapper createLocalObjectMapper() {
         ObjectMapper om = new ObjectMapper();
         om.registerModule(new JavaTimeModule());
@@ -57,7 +56,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String path = request.getRequestURI();
 
         if ("GET".equalsIgnoreCase(request.getMethod()) &&
-                ("/api/v1/product".equals(path) || "/api/v1/raffles".equals(path))) {
+                (pathMatcher.match("/api/v1/product/**", path)
+                        || pathMatcher.match("/api/v1/raffles/**", path))) {
             return true;
         }
 


### PR DESCRIPTION
## 📌 개요
- 관리자 와 사용자 권한을 분리 

## 🚀 관련 이슈
- close #114 

## ✅ 변경 사항
- flter 에서 인증 없어도 되는 url은 skip 처리
- 각 endpoint마다 권한 어노테이션 설정

## 📝 상세 내용
- 인증 필요없는 endpoint 는 filter 통하지 않도록 처리
- endpoint마다 권한 부여
- @CheckPermission(roles = {"ADMIN"}, mode = CheckPermission.Mode.ALL, page = CheckPermission.Page.BO)
roles = "ADMIN" , "USER" 
mode = ALL : 전체 적용, ANY : roles중에 하나  
* 우리는 아이디에 권한이 한개이기 때문에 ANY만 사용!
page = BO : backOffice 에러 시 상세 메세지 , FO : 에러 시 간단메세지

## 📚 관련 문서
-
