### PR TITLE
Feature/coupon cache 프론트 결제 시 쿠폰 미적용 문제 및 쿠폰 Redis 캐싱 기능 오류 해결

### DIFF
--- a/backend/src/main/java/groom/backend/domain/coupon/policy/DiscountAmountMultiPolicy.java
+++ b/backend/src/main/java/groom/backend/domain/coupon/policy/DiscountAmountMultiPolicy.java
@@ -15,6 +15,7 @@ public class DiscountAmountMultiPolicy implements DiscountMultiPolicy {
 
   @Override
   public int calculateMultiDiscount(List<DiscountContext> discountContexts) {
+    if (discountContexts.isEmpty()) return 0;
     return discountContexts.stream()
             .mapToInt(DiscountContext::getAmount)
             .sum();

--- a/backend/src/main/java/groom/backend/domain/coupon/policy/DiscountPercentMultiPolicy.java
+++ b/backend/src/main/java/groom/backend/domain/coupon/policy/DiscountPercentMultiPolicy.java
@@ -17,11 +17,12 @@ public class DiscountPercentMultiPolicy implements DiscountMultiPolicy {
 
   @Override
   public int calculateMultiDiscount(List<DiscountContext> discountContexts) {
+    if (discountContexts.isEmpty()) return 0;
     // 할인율을 동일하게 하기 위해 정렬
     List<DiscountContext> sortedContext = discountContexts.stream()
             .sorted(Comparator.comparingInt(DiscountContext::getAmount))
             .toList();
-    int cost = discountContexts.get(0).getCost();
+    int cost = discountContexts.getFirst().getCost();
 
     for (DiscountContext discountContext : sortedContext) {
       double rate = discountContext.getAmount() / 100.0;

--- a/backend/src/main/java/groom/backend/infrastructure/config/RedisConfig.java
+++ b/backend/src/main/java/groom/backend/infrastructure/config/RedisConfig.java
@@ -26,6 +26,7 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 import java.time.Duration;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @Configuration
@@ -101,7 +102,7 @@ public class RedisConfig {
     }
 
 
-    @Bean
+    @Bean(name = "couponCacheTemplate")
     public RedisTemplate<String, CouponIssueResponse> couponCacheTemplate(
             RedisConnectionFactory redisConnectionFactory,
             ObjectMapper objectMapper) { // 3. (선택적) ObjectMapper 주입
@@ -133,7 +134,7 @@ public class RedisConfig {
     /**
      * @Cacheable, @CacheEvict 등 Spring Cache 추상화가 사용할 CacheManager
      */
-    @Bean
+    @Bean(name = "couponCacheManager")
     public CacheManager couponCacheManager(RedisConnectionFactory redisConnectionFactory) {
 
         // 4. CacheManager 전용 ObjectMapper 설정 (Type 정보 포함)

--- a/frontend/app/cart/page.tsx
+++ b/frontend/app/cart/page.tsx
@@ -235,6 +235,22 @@ export default function CartPage() {
       toast.error('장바구니가 비어있습니다.');
       return;
     }
+    
+    // 선택한 쿠폰 정보를 sessionStorage에 저장
+    if (selectedCoupon) {
+      const selectedCouponData = coupons.find(c => String(c.id) === String(selectedCoupon));
+      if (selectedCouponData) {
+        sessionStorage.setItem('selectedCoupon', JSON.stringify({
+          couponId: selectedCoupon,
+          couponName: selectedCouponData.name,
+          couponType: selectedCouponData.type,
+          couponAmount: selectedCouponData.amount,
+        }));
+      }
+    } else {
+      sessionStorage.removeItem('selectedCoupon');
+    }
+    
     router.push('/order');
   };
 


### PR DESCRIPTION
## 📌 개요
- 결제 시 쿠폰 선택 후 결제창으로 넘어가면 쿠폰이 적용되지 않는 현상과 그 외 오류들을 해결한다.

## 🚀 관련 이슈
- #148 
- #155

## ✅ 변경 사항
- 프론트 쿠폰 사용 적용
- Redis 캐싱 기능 수정
- 정책 엣지 케이스 오류 해결

## 📝 상세 내용
- 장바구니 페이지에서 주문 페이지로 넘어갈 시 쿠폰 정보도 함께 넘기도록 수정
- Redis에서 단건 쿠폰 저장 시 배열 대신 객체 형태로 저장하도록 수정
- * 이로 인해 TTL 적용되지 않는 문제를 MultiSet을 통한 단 건 쿠폰 등록을 for 루프를 통해 등록하도록 수정
- 다중 쿠폰 사용 정책에서 특정 정책의 쿠폰이 사용되지 않을 경우 Empty List Exception이 뜨던 문제 수정

## 📚 관련 문서
- 
