### PR TITLE
Feature/raffle scheduling 추첨 일에 자동으로 추첨되는 기능 추가

### DIFF
--- a/backend/src/main/java/groom/backend/application/raffle/RaffleDrawApplicationService.java
+++ b/backend/src/main/java/groom/backend/application/raffle/RaffleDrawApplicationService.java
@@ -35,11 +35,18 @@ public class RaffleDrawApplicationService {
     private final ProductApplicationService productApplicationService;
     private final NotificationApplicationService notificationApplicationService;
 
+    // 수동 추첨 메서드
     @Transactional
     public void drawRaffleWinners(User user, Long raffleId) {
         // 관리자 권한 검증
         validationService.ensureAdmin(user);
 
+        executeDrawing(raffleId);
+    }
+
+    // 실제 추첨 로직 (kafka 에서 실행)
+    @Transactional
+    public void executeDrawing(Long raffleId) {
         // 추첨 존재 여부 및 상태 검증
         Raffle raffle = validationService.findById(raffleId);
 

--- a/backend/src/main/java/groom/backend/application/raffle/RaffleScheduler.java
+++ b/backend/src/main/java/groom/backend/application/raffle/RaffleScheduler.java
@@ -1,8 +1,12 @@
 package groom.backend.application.raffle;
 
 import groom.backend.domain.raffle.entity.Raffle;
+import groom.backend.domain.raffle.entity.RaffleDrawingEvent;
 import groom.backend.domain.raffle.enums.RaffleStatus;
 import groom.backend.domain.raffle.repository.RaffleRepository;
+import groom.backend.infrastructure.kafka.raffle.DrawingEventProducer;
+import groom.backend.infrastructure.redis.RaffleDelayedDrawingQueue;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -11,6 +15,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
+import java.util.Set;
 
 @Slf4j
 @Component
@@ -19,11 +24,18 @@ public class RaffleScheduler {
 
     private final RaffleRepository raffleRepository;
     private final RaffleApplicationService raffleService; // 상태 변경 + 이벤트 발행을 담당 (트랜잭션 내부 처리)
+    private final RaffleDelayedDrawingQueue raffleDelayedDrawingQueue;
+    private final DrawingEventProducer eventProducer;
 
     private static final int PAGE_SIZE = 100; // 적절한 청크 크기로 조정
 
-    @Scheduled(cron = "30 0 0 * * *") // 매일 자정 1분에 실행
-    //@Scheduled(cron = "0 14 17 * * *")
+    @PostConstruct
+    public void detectDuplicateInstance() {
+        log.info("RaffleScheduler initialized, instanceHash={} ", System.identityHashCode(this));
+    }
+
+    @Scheduled(cron = "30 0 0 * * *") // 매일 자정 30초에 실행
+    //@Scheduled(cron = "0 */5 * * * *") // 테스트 용도로 5분마다 실행
     public void changeRaffleStatusToActive() {
         LocalDateTime now = LocalDateTime.now();
         int page = 0;
@@ -46,12 +58,11 @@ public class RaffleScheduler {
         } while (!chunk.isLast());
     }
 
-     @Scheduled(cron = "0 1 0 * * *") // 매일 자정 1분에 실행
-    //@Scheduled(cron = "0 14 17 * * *")
+    @Scheduled(cron = "0 1 0 * * *") // 매일 자정 1분에 실행
+    //@Scheduled(cron = "0 */5 * * * *")
     public void changeRaffleStatusToClosed() {
         LocalDateTime now = LocalDateTime.now();
         int page = 0;
-
 
         Page<Raffle> chunk;
         do {
@@ -60,7 +71,21 @@ public class RaffleScheduler {
             chunk = raffleRepository.findAllByStatusAndEntryEndAtBefore(RaffleStatus.ACTIVE, now, pr);
             chunk.getContent().forEach(raffle -> {
                 try {
+                    // 1. 기존 마감 처리 로직
                     raffleService.updateRaffleStatus(raffle, RaffleStatus.CLOSED);
+
+                    // 2. Redis에 추첨 실행 예약 등록
+                    RaffleDrawingEvent event = RaffleDrawingEvent.builder()
+                            .raffleId(raffle.getRaffleId())
+                            .drawingExecutionTime(raffle.getRaffleDrawAt())
+                            .registeredAt(LocalDateTime.now())
+                            .build();
+
+                    raffleDelayedDrawingQueue.scheduleDrawing(event);
+
+                    log.info("추첨 마감 및 실행 예약 완료 - raffleId: {}, 실행예정: {}",
+                            raffle.getRaffleId(),
+                            event.getDrawingExecutionTime());
                 } catch (Exception e) {
                     // 로깅 및 예외 처리
                     log.error("Error closed raffle ID {}: {}", raffle.getRaffleId(), e.getMessage());
@@ -69,6 +94,43 @@ public class RaffleScheduler {
 
             page++;
         } while (!chunk.isLast());
+    }
+
+    /**
+     * 1분 마다 Redis를 체크해서 실행 시간이 된 추첨을 Kafka로 발행
+     */
+    @Scheduled(fixedDelay = 6000000, initialDelay = 10000)
+    public void processScheduledDrawings() {
+        log.debug("지연된 추첨 처리 시작");
+
+        try {
+            Set<RaffleDrawingEvent> readyEvents = raffleDelayedDrawingQueue.getReadyToExecuteDrawings();
+
+            if (readyEvents == null || readyEvents.isEmpty()) {
+                return;
+            }
+
+            log.info("처리할 추첨 발견: {} 건", readyEvents.size());
+
+            // 각 이벤트를 Kafka로 발행
+            for (RaffleDrawingEvent event : readyEvents) {
+                try {
+                    // Kafka로 추첨 실행 메시지 발행
+                    eventProducer.publishRaffleDrawingEvent(event);
+
+                    // Redis에서 제거
+                    raffleDelayedDrawingQueue.removeProcessedDrawing(event);
+
+                    log.info("추첨 실행 메시지 발행 및 Redis 제거 완료 - raffleId: {}",
+                            event.getRaffleId());
+                } catch (Exception e) {
+                    log.error("추첨 실행 메시지 발행 실패 - raffleId: {} (다음 스케줄에서 재시도)",
+                            event.getRaffleId(), e);
+                }
+            }
+        } catch (Exception e) {
+            log.error("지연된 추첨 처리 중 오류 발생", e);
+        }
     }
 
 }

--- a/backend/src/main/java/groom/backend/common/exception/ErrorCode.java
+++ b/backend/src/main/java/groom/backend/common/exception/ErrorCode.java
@@ -97,6 +97,9 @@ public enum ErrorCode {
     // 추첨 시작 전 검증(별도)
     RAFFLE_DRAW_NOT_STARTED             (HttpStatus.BAD_REQUEST, "아직 추첨일이 되지 않았습니다."),
 
+    // 내부 처리 오류
+    RAFFLE_DRAWING_EVENT_PUBLISH_FAILED (HttpStatus.INTERNAL_SERVER_ERROR, "추첨 실행 이벤트 발행에 실패했습니다."),
+
     // ===================== Cart 에러 코드 ====================
     /** 장바구니가 존재하지 않음 */
     CART_NOT_FOUND                      (HttpStatus.NOT_FOUND, "장바구니가 존재하지 않습니다."),

--- a/backend/src/main/java/groom/backend/domain/raffle/entity/RaffleDrawingEvent.java
+++ b/backend/src/main/java/groom/backend/domain/raffle/entity/RaffleDrawingEvent.java
@@ -1,16 +1,12 @@
 package groom.backend.domain.raffle.entity;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.Value;
 
 import java.time.LocalDateTime;
 
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
+@Value
+@Builder(toBuilder = false)
 public class RaffleDrawingEvent {
 
     private Long raffleId;

--- a/backend/src/main/java/groom/backend/domain/raffle/entity/RaffleDrawingEvent.java
+++ b/backend/src/main/java/groom/backend/domain/raffle/entity/RaffleDrawingEvent.java
@@ -1,0 +1,19 @@
+package groom.backend.domain.raffle.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RaffleDrawingEvent {
+
+    private Long raffleId;
+    private LocalDateTime drawingExecutionTime;   // 추첨이 실제로 진행된 시간
+    private LocalDateTime registeredAt; // 이벤트가 생성된 시간
+}

--- a/backend/src/main/java/groom/backend/infrastructure/kafka/raffle/DrawingEventProducer.java
+++ b/backend/src/main/java/groom/backend/infrastructure/kafka/raffle/DrawingEventProducer.java
@@ -1,7 +1,5 @@
 package groom.backend.infrastructure.kafka.raffle;
 
-import groom.backend.common.exception.BusinessException;
-import groom.backend.common.exception.ErrorCode;
 import groom.backend.domain.raffle.entity.RaffleDrawingEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,7 +20,7 @@ public class DrawingEventProducer {
     /**
      * 추첨 실행 이벤트를 Kafka로 발행
      */
-    public void publishRaffleDrawingEvent(RaffleDrawingEvent event) {
+    public CompletableFuture<SendResult<String, RaffleDrawingEvent>> publishRaffleDrawingEvent(RaffleDrawingEvent event) {
         String key = String.valueOf(event.getRaffleId());
 
         CompletableFuture<SendResult<String, RaffleDrawingEvent>> future = kafkaTemplate.send(TOPIC, key, event);
@@ -35,8 +33,9 @@ public class DrawingEventProducer {
                         result.getRecordMetadata().offset());
             } else {
                 log.error("추첨 실행 이벤트 발행 실패 - raffleId: {}", event.getRaffleId(), ex);
-                throw  new BusinessException(ErrorCode.RAFFLE_DRAWING_EVENT_PUBLISH_FAILED);
             }
         });
+
+        return future;
     }
 }

--- a/backend/src/main/java/groom/backend/infrastructure/kafka/raffle/DrawingEventProducer.java
+++ b/backend/src/main/java/groom/backend/infrastructure/kafka/raffle/DrawingEventProducer.java
@@ -1,0 +1,42 @@
+package groom.backend.infrastructure.kafka.raffle;
+
+import groom.backend.common.exception.BusinessException;
+import groom.backend.common.exception.ErrorCode;
+import groom.backend.domain.raffle.entity.RaffleDrawingEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.CompletableFuture;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DrawingEventProducer {
+    private static final String TOPIC = "drawing-execute-topic";
+
+    private final KafkaTemplate<String, RaffleDrawingEvent> kafkaTemplate;
+
+    /**
+     * 추첨 실행 이벤트를 Kafka로 발행
+     */
+    public void publishRaffleDrawingEvent(RaffleDrawingEvent event) {
+        String key = String.valueOf(event.getRaffleId());
+
+        CompletableFuture<SendResult<String, RaffleDrawingEvent>> future = kafkaTemplate.send(TOPIC, key, event);
+
+        future.whenComplete((result, ex) -> {
+            if (ex == null) {
+                log.info("추첨 실행 이벤트 발행 성공 - drawingId: {}, partition: {}, offset: {}",
+                        event.getRaffleId(),
+                        result.getRecordMetadata().partition(),
+                        result.getRecordMetadata().offset());
+            } else {
+                log.error("추첨 실행 이벤트 발행 실패 - raffleId: {}", event.getRaffleId(), ex);
+                throw  new BusinessException(ErrorCode.RAFFLE_DRAWING_EVENT_PUBLISH_FAILED);
+            }
+        });
+    }
+}

--- a/backend/src/main/java/groom/backend/infrastructure/kafka/raffle/DrawingEventProducer.java
+++ b/backend/src/main/java/groom/backend/infrastructure/kafka/raffle/DrawingEventProducer.java
@@ -27,7 +27,7 @@ public class DrawingEventProducer {
 
         future.whenComplete((result, ex) -> {
             if (ex == null) {
-                log.info("추첨 실행 이벤트 발행 성공 - drawingId: {}, partition: {}, offset: {}",
+                log.info("추첨 실행 이벤트 발행 성공 - raffleId: {}, partition: {}, offset: {}",
                         event.getRaffleId(),
                         result.getRecordMetadata().partition(),
                         result.getRecordMetadata().offset());

--- a/backend/src/main/java/groom/backend/infrastructure/kafka/raffle/DrawingExecutionConsumer.java
+++ b/backend/src/main/java/groom/backend/infrastructure/kafka/raffle/DrawingExecutionConsumer.java
@@ -1,0 +1,53 @@
+package groom.backend.infrastructure.kafka.raffle;
+
+
+import groom.backend.application.raffle.RaffleDrawApplicationService;
+import groom.backend.domain.raffle.entity.RaffleDrawingEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DrawingExecutionConsumer {
+
+    private final RaffleDrawApplicationService drawingService;
+
+    @KafkaListener(
+            topics = "drawing-execute-topic",
+            groupId = "drawing-executor-group",
+            containerFactory = "raffleDrawingKafkaListenerContainerFactory" // 변경: 수동 ACK 팩토리 사용
+    )
+    public void executeDrawing(
+            RaffleDrawingEvent event,
+            Acknowledgment acknowledgment) {
+
+        log.info("추첨 실행 메시지 수신 - raffleId: {}", event.getRaffleId());
+
+        try {
+            // 기존 추첨 실행 로직 호출
+            drawingService.executeDrawing(event.getRaffleId());
+
+            // 수동 커밋
+            acknowledgment.acknowledge();
+
+            // 알림은 별도 try/catch로 감싸서 실패를 격리
+            try {
+                drawingService.sendRaffleWinnersNotification(event.getRaffleId());
+                log.info("당첨자 알림 전송 완료 - raffleId: {}", event.getRaffleId());
+            } catch (Exception notifyEx) {
+                log.error("당첨자 알림 전송 실패(무시) - raffleId: {}", event.getRaffleId(), notifyEx);
+                // 권장: 실패한 알림을 재시도/큐/DB에 저장하는 로직 추가
+            }
+
+            log.info("추첨 실행 완료 - raffleId: {}", event.getRaffleId());
+
+        } catch (Exception e) {
+            log.error("추첨 실행 실패 - raffleId: {}", event.getRaffleId(), e);
+            // acknowledge 하지 않으면 재시도됨
+        }
+    }
+}

--- a/backend/src/main/java/groom/backend/infrastructure/redis/RaffleDelayedDrawingQueue.java
+++ b/backend/src/main/java/groom/backend/infrastructure/redis/RaffleDelayedDrawingQueue.java
@@ -1,0 +1,109 @@
+package groom.backend.infrastructure.redis;
+
+import groom.backend.domain.raffle.entity.RaffleDrawingEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.ZoneId;
+import java.util.Set;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RaffleDelayedDrawingQueue {
+
+    private static final String DELAYED_QUEUE_KEY = "drawing:delayed:queue";
+
+    private final RedisTemplate<String, RaffleDrawingEvent> raffleDrawingRedisTemplate;
+
+    /**
+     * 추첨 실행 예약 등록
+     * Redis Sorted Set에 실행 시간을 score로 저장
+     */
+    public void scheduleDrawing(RaffleDrawingEvent event) {
+        try {
+            // 실행 시간을 epoch milliseconds로 변환 (score)
+            long executeTimeScore = event.getDrawingExecutionTime()
+                    .atZone(ZoneId.systemDefault())
+                    .toInstant()
+                    .toEpochMilli();
+
+            // Redis Sorted Set에 추가
+            raffleDrawingRedisTemplate.opsForZSet()
+                    .add(DELAYED_QUEUE_KEY, event, executeTimeScore);
+
+            log.info("추첨 실행 예약 등록 완료 - raffleId: {}, 실행예정시간: {}, score: {}",
+                    event.getRaffleId(),
+                    event.getDrawingExecutionTime(),
+                    executeTimeScore);
+
+        } catch (Exception e) {
+            log.error("추첨 실행 예약 등록 실패 - raffleId: {}", event.getRaffleId(), e);
+            throw new RuntimeException("추첨 실행 예약 등록 실패", e);
+        }
+    }
+
+    /**
+     * 실행 시간이 된 추첨 이벤트 조회
+     */
+    public Set<RaffleDrawingEvent> getReadyToExecuteDrawings() {
+        try {
+            long now = System.currentTimeMillis();
+
+            // 현재 시간 이전의 모든 이벤트 조회
+            Set<RaffleDrawingEvent> events = raffleDrawingRedisTemplate.opsForZSet()
+                    .rangeByScore(DELAYED_QUEUE_KEY, 0, now);
+
+            if (events != null && !events.isEmpty()) {
+                log.info("실행 대기중인 추첨 발견: {} 건", events.size());
+            }
+
+            return events;
+
+        } catch (Exception e) {
+            log.error("실행 대기 추첨 조회 실패", e);
+            return Set.of();
+        }
+    }
+
+    /**
+     * 처리 완료된 이벤트 제거
+     */
+    public void removeProcessedDrawing(RaffleDrawingEvent event) {
+        try {
+            Long removed = raffleDrawingRedisTemplate.opsForZSet()
+                    .remove(DELAYED_QUEUE_KEY, event);
+
+            if (removed != null && removed > 0) {
+                log.info("처리 완료된 추첨 제거 - raffleId: {}", event.getRaffleId());
+            }
+
+        } catch (Exception e) {
+            log.error("처리 완료 추첨 제거 실패 - raffleId: {}", event.getRaffleId(), e);
+        }
+    }
+
+    /**
+     * 특정 추첨 스케줄 취소
+     */
+    public void cancelSchedule(Long raffleId) {
+        try {
+            Set<RaffleDrawingEvent> allEvents = raffleDrawingRedisTemplate.opsForZSet()
+                    .range(DELAYED_QUEUE_KEY, 0, -1);
+
+            if (allEvents != null) {
+                allEvents.stream()
+                        .filter(event -> event.getRaffleId().equals(raffleId))
+                        .forEach(event -> {
+                            raffleDrawingRedisTemplate.opsForZSet()
+                                    .remove(DELAYED_QUEUE_KEY, event);
+                            log.info("추첨 스케줄 취소 - raffleId: {}", raffleId);
+                        });
+            }
+        } catch (Exception e) {
+            log.error("추첨 스케줄 취소 실패 - raffleId: {}", raffleId, e);
+        }
+    }
+}


### PR DESCRIPTION
## 📌 개요
- 추첨일에 자동으로 추첨되도록 설정

## 🚀 관련 이슈
- close #161 

## ✅ 변경 사항
- redis 설정
- kafka 설정
- 스케줄러 추가

## 📝 상세 내용
- 스케줄러에서 응모 종료일에 추첨 상태값을 close 하면서 추첨일에 추첨되도록 redis에 설정
- 스케줄러에 추첨일까지 계속 체크
- 추첨일 되면 kafka 이벤트 발행 및 추첨 실행

## 📚 관련 문서
-
